### PR TITLE
[Fix] 헤더 수정사항 반영

### DIFF
--- a/src/components/commons/Header.styled.ts
+++ b/src/components/commons/Header.styled.ts
@@ -2,7 +2,7 @@ import styled from "styled-components";
 
 export const HeaderWrapper = styled.header`
   display: flex;
-  padding: 0.5rem 1rem;
+  padding: 0.5rem 0 0.5rem 1rem;
 
   background-color: ${({ theme }) => theme.colors.UI_background};
   cursor: pointer;
@@ -21,14 +21,17 @@ export const BtnLayout = styled.section`
 
 export const SearchBtn = styled.button`
   display: flex;
+  padding: 0;
 `;
 
 export const MyBtn = styled.button`
   display: flex;
   align-items: center;
+  padding: 0 0.8rem;
 `;
 
 export const HamburgerBtn = styled.button`
   display: flex;
   align-items: center;
+  padding: 0 1rem;
 `;

--- a/src/components/commons/Header.tsx
+++ b/src/components/commons/Header.tsx
@@ -3,7 +3,7 @@ import { IcHamburger, IcLogo, IcMy, IcSearch } from "../../assets/icons";
 import * as S from "./Header.styled.ts";
 
 interface HeaderPropTypes {
-  navigateSearch: () => void;
+  navigateSearch?: () => void;
 }
 
 const Header = ({ navigateSearch }: HeaderPropTypes) => {


### PR DESCRIPTION
### ✨ 해당 이슈 번호

resolved #6 

### 🌱 작업 내용

- [x] 헤더 패딩 값 수정
- [x] 라우팅 함수 옵셔널로 전달


### ✅ PR Point
```tsx
interface HeaderPropTypes {
  navigateSearch?: () => void;
}
```
돋보기 버튼을 클릭할 필요가 없는 뷰가 있어서 prop을 옵셔널 값으로 전달해주는 방향으로 수정했습니다.


### 👀 스크린샷 (선택)

<img width="391" alt="스크린샷 2024-05-15 오후 7 35 47" src="https://github.com/NOWSOPT-CDSP-WEB-7/YES24-WEB-CLIENT/assets/96781926/cd8abb3f-17e3-45f5-b7c0-0a8f2fb1dfa8">

