### PR TITLE
[Fix] 공통 헤더 position 추가

### DIFF
--- a/src/components/commons/Header.styled.ts
+++ b/src/components/commons/Header.styled.ts
@@ -1,7 +1,9 @@
 import styled from "styled-components";
 
 export const HeaderWrapper = styled.header`
+  position: fixed;
   display: flex;
+  width: 100%;
   padding: 0.5rem 0 0.5rem 1rem;
 
   background-color: ${({ theme }) => theme.colors.UI_background};


### PR DESCRIPTION
### ✨ 해당 이슈 번호

resolved #53 

### 🌱 작업 내용

- [x] 헤더 position 고정
- [x] 헤더 바로 아래의 컴포넌트 padding-top 추가


### ✅ PR Point
**헤더 fixed 변경으로 인한 수정사항**
- 헤더를 fixed로 설정하면서 기존 컴포넌트가 가려지는 현상이 있습니다.
- 다들 본인 페이지에서 헤더 바로 아래에 위치하는 컴포넌트의 `padding-top` 값으로 `4.4rem`을 추가해주셔야 뷰가 정상적으로 보일거에요!
- 늦게 발견하고 고쳐서 미안합니다..! 요거는 공통 컴포넌트이니 바로 develop으로 머지할게요!


### 🌱 Trouble Shooting
- 없습니다


### 👀 스크린샷 (선택)

https://github.com/NOWSOPT-CDSP-WEB-7/YES24-WEB-CLIENT/assets/96781926/8f5e2dbd-b8db-4f59-97fd-fc3c9d38f89a
