### PR TITLE
[Feat] Detail 뷰 하단 예매하기 버튼

### DIFF
--- a/src/pages/Detail/Detail.tsx
+++ b/src/pages/Detail/Detail.tsx
@@ -1,7 +1,9 @@
-import SaleCoupon from "./components/SaleCoupon";
+import Footer from "../../components/commons/Footer/Footer";
 import Header from "../../components/commons/Header/Header";
-import ShowInfo from "./components/ShowInfo";
 import Category from "./components/Category";
+import ReserveBtn from "./components/ReserveBtn/ReserveBtn";
+import SaleCoupon from "./components/SaleCoupon";
+import ShowInfo from "./components/ShowInfo";
 
 const Detail = () => {
   return (
@@ -10,6 +12,8 @@ const Detail = () => {
       <ShowInfo />
       <SaleCoupon />
       <Category />
+      <Footer />
+      <ReserveBtn />
     </>
   );
 };

--- a/src/pages/Detail/components/ReserveBtn/ReserveBtn.styled.ts
+++ b/src/pages/Detail/components/ReserveBtn/ReserveBtn.styled.ts
@@ -1,0 +1,21 @@
+import styled from "styled-components";
+
+export const BtnWrapper = styled.section`
+  position: fixed;
+  bottom: 0;
+  width: 100%;
+  padding: 2rem 1rem;
+
+  background-color: ${({ theme }) => theme.colors.UI_background};
+`;
+
+export const Button = styled.button`
+  width: 100%;
+  padding: 1.2rem;
+
+  color: ${({ theme }) => theme.colors.UI_background};
+
+  background-color: ${({ theme }) => theme.colors.Secondary_orange};
+  border-radius: 0.2rem;
+  ${({ theme }) => theme.fonts.title_18pt_Bold};
+`;

--- a/src/pages/Detail/components/ReserveBtn/ReserveBtn.tsx
+++ b/src/pages/Detail/components/ReserveBtn/ReserveBtn.tsx
@@ -1,0 +1,11 @@
+import * as S from "./ReserveBtn.styled";
+
+const ReserveBtn = () => {
+  return (
+    <S.BtnWrapper>
+      <S.Button>예매하기</S.Button>
+    </S.BtnWrapper>
+  );
+};
+
+export default ReserveBtn;


### PR DESCRIPTION
### ✨ 해당 이슈 번호

resolved #49 

### 🌱 작업 내용

- [x] 예매하기 버튼 구현
- [x] 버튼 하단 fixed로 고정


### ✅ PR Point
- 흠.. 너무 간단해서 딱히 없네요..버튼 자체는 button태그 사용했고, 감싸주는 태그는 section 태그 사용했습니다. 시맨틱 태그를 계속 생각하면서 활용하려고 노력 중인데 쉽지 않네요🥹


### 🌱 Trouble Shooting
- 없습니다


### 👀 스크린샷 (선택)
- 스크롤을 보여드리기 위해 급한대로 Footer 컴포넌트를 두 개 불러왔습니다! 참고해주세요

https://github.com/NOWSOPT-CDSP-WEB-7/YES24-WEB-CLIENT/assets/96781926/2cf0f4ee-8508-4a41-b33a-b4c031ea4852

