### PR TITLE
[Fix] 최근 검색어 border-bottom 추가, 전체삭제 버튼 추가

### DIFF
--- a/src/components/commons/SearchedShow/SearchedShow.tsx
+++ b/src/components/commons/SearchedShow/SearchedShow.tsx
@@ -1,6 +1,5 @@
 import * as S from "./SearchedShow.styled";
 import showImg from "../../../assets/images/show.png";
-import DeleteAllBtn from "../DeleteAllBtn/DeleteAllBtn";
 const SearchedShow = () => {
   return (
     <>
@@ -25,7 +24,6 @@ const SearchedShow = () => {
           </S.PeriodAndPlace>
         </S.ShowRightSec>
       </S.ShowWrapper>
-      <DeleteAllBtn />
     </>
   );
 };

--- a/src/pages/Search/Search.tsx
+++ b/src/pages/Search/Search.tsx
@@ -2,7 +2,7 @@ import * as S from "./Search.styled.ts";
 import SearchBar from "./components/SearchBar/SearchBar.tsx";
 import SearchHeader from "./components/SearchHeader/SearchHeader.tsx";
 import CategoryTab from "./components/CategoryTab/CategoryTab.tsx";
-import Footer from "../../components/commons/Footer.tsx";
+import Footer from "@components/commons/Footer/Footer.tsx";
 
 const Search = () => {
   return (

--- a/src/pages/Search/components/RecentShows/RecentShows.tsx
+++ b/src/pages/Search/components/RecentShows/RecentShows.tsx
@@ -1,9 +1,11 @@
+import DeleteAllBtn from "@components/commons/DeleteAllBtn/DeleteAllBtn";
 import SearchedShow from "../../../../components/commons/SearchedShow/SearchedShow";
 
 const RecentShows = () => {
   return (
     <>
       <SearchedShow />
+      <DeleteAllBtn />
     </>
   );
 };

--- a/src/pages/Search/components/RecentWord/RecentWord.styled.ts
+++ b/src/pages/Search/components/RecentWord/RecentWord.styled.ts
@@ -7,7 +7,7 @@ export const WordWrapper = styled.article`
   width: 100%;
   padding: 1rem 1rem 1rem 2rem;
 
-  border-bottom: ${({ theme }) => theme.colors.UI_02};
+  border-bottom: 1px solid ${({ theme }) => theme.colors.UI_02};
 `;
 export const Word = styled.span`
   color: ${({ theme }) => theme.colors.Text_strong};

--- a/src/pages/Search/components/RecentWords/RecentWords.tsx
+++ b/src/pages/Search/components/RecentWords/RecentWords.tsx
@@ -1,5 +1,6 @@
 import * as S from "./RecentWords.styled";
 import RecentWord from "../RecentWord/RecentWord";
+import DeleteAllBtn from "@components/commons/DeleteAllBtn/DeleteAllBtn";
 
 const RecentWords = () => {
   const words = ["레베카", "울산", "서울"];
@@ -7,15 +8,18 @@ const RecentWords = () => {
     return <div>최근 검색어가 없습니다.</div>;
   }
   return (
-    <S.Wrapper>
-      {words && (
-        <div>
-          {words.map((word, i) => {
-            return <RecentWord key={i} word={word} />;
-          })}
-        </div>
-      )}
-    </S.Wrapper>
+    <>
+      <S.Wrapper>
+        {words && (
+          <div>
+            {words.map((word, i) => {
+              return <RecentWord key={i} word={word} />;
+            })}
+          </div>
+        )}
+      </S.Wrapper>
+      <DeleteAllBtn />
+    </>
   );
 };
 


### PR DESCRIPTION
### ✨ 해당 이슈 번호

resolved #64 

### 🌱 작업 내용

- [x] ~ RecentWord의 각 검색어 border-bottom에 컬러만 지정하고 1px solid를 안줬었네요
- [x] ~ 전체삭제 버튼 추가했습니다.


### ✅ PR Point
- ~ 부분 이렇게 구현했어요, 피드백 부탁해요!


### 🌱 Trouble Shooting
- 개발 중 겪은 트러블 정리!


### 👀 스크린샷 (선택)
<img width="402" alt="스크린샷 2024-05-22 오후 12 44 03" src="https://github.com/NOWSOPT-CDSP-WEB-7/YES24-WEB-CLIENT/assets/101498590/5c3a2bd6-07b5-4e11-87b4-f2cd7770a94c">


### 📚 Reference
