### PR TITLE
[Feat] 검색어 localStorage에 저장 및 get api요청 로직 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ dist-ssr
 *.sln
 *.sw?
 .env
+.env.local
 
 #dermy-data
 /public/data/search-result.json

--- a/src/apis/SearchApi/getSearchResult.ts
+++ b/src/apis/SearchApi/getSearchResult.ts
@@ -1,0 +1,17 @@
+import axios from "axios";
+
+export const getSearchResult = async (input: string) => {
+  try {
+    const response = await axios.get(
+      `${import.meta.env.VITE_BASE_URL}/runshow/search/?query=${input}`,
+      {
+        headers: {
+          "Content-Type": "application/json",
+        },
+      }
+    );
+    return response.data.data;
+  } catch (error) {
+    console.log(error);
+  }
+};

--- a/src/pages/Search/components/SearchBar/SearchBar.tsx
+++ b/src/pages/Search/components/SearchBar/SearchBar.tsx
@@ -2,20 +2,40 @@ import * as S from "./SearchBar.styled.ts";
 import { IcSearch, IcCancel } from "../../../../assets/icons";
 import useChangeInput from "../../../../hooks/useChangeInput.ts";
 import SearchList from "../SearchList/SearchList.tsx";
+import { useNavigate } from "react-router-dom";
 
 const SearchBar = () => {
   const { input, handleInputChange } = useChangeInput();
+  const navigate = useNavigate();
+  const handleSearchClick = async () => {
+    if (input.trim().length === 0) {
+      return;
+    }
+
+    localStorage.setItem("searchWord", input);
+
+    navigate("list");
+  };
+  const handleKeyPress = (e: { key: string }) => {
+    if (e.key === "Enter") {
+      handleSearchClick();
+    }
+  };
   return (
     <S.SearchBarAndListWrapper>
       <S.SearchBarContainer>
         <S.SearchBarWrapper>
-          <S.SearchBarInput placeholder="검색어를 입력해주세요" onChange={handleInputChange} />
+          <S.SearchBarInput
+            placeholder="검색어를 입력해주세요"
+            onChange={handleInputChange}
+            onKeyDown={handleKeyPress}
+          />
           {input.trim().length !== 0 && (
             <S.CancelBtn>
               <IcCancel />
             </S.CancelBtn>
           )}
-          <S.SearchBtn>
+          <S.SearchBtn onClick={handleSearchClick}>
             <IcSearch />
           </S.SearchBtn>
         </S.SearchBarWrapper>


### PR DESCRIPTION
### ✨ 해당 이슈 번호

resolved #66 

### 🌱 작업 내용

- [x] ~ 검색어 입력후 엔터키 혹은 돋보기 버튼 클릭시 /list 페이지로 라우팅
- [x] ~ 이때 locaclStorage에 검색어 저장
- [x] ~ search result get 하는 로직 구현


### ✅ PR Point
- ~ 부분 이렇게 구현했어요, 피드백 부탁해요!
- input값이 띄워쓰기같은 공백으로 빈값을 보내면 return처리 했습니다.
- searchWord 라는 key값으로 검색어를 localStorage에 저장했습니다.


### 🌱 Trouble Shooting
- 개발 중 겪은 트러블 정리!
- 검색어를 입력한 후 돋보기 버튼 혹은 엔터키를 눌렀을 때 /search/list페이지로 라우팅 되며 검색어에 대한 결과값을 가져와야 하는데 이 로직을 어떤식으로 구현할지 고민이 되었습니다.
1. /search 페이지에서 검색어 입력 후 돋보기 버튼 혹은 엔터키를 눌렀을 때 검색어 localStorage에 저장도 하고, 라우팅도 하고, api get요청도 보내고 다 하는 방법
2. /search 페이지에선 localStorage저장, 라우팅만 하고, /search/list 페이지에서 localStorage의 값을 가져와 api get요청하는 방법
둘 중 저는 2번 방식을 선택했습니다. 추후 유지보수가 더 좋을것 같아서?

### 👀 스크린샷 (선택)

https://github.com/NOWSOPT-CDSP-WEB-7/YES24-WEB-CLIENT/assets/101498590/b6dc9132-58da-43c5-b7ce-5ad222ea67c8



### 📚 Reference

