### PR TITLE
[Fix] 이미지 사이 공백 제거

### DIFF
--- a/src/pages/Detail/components/ExpectComment/ExpectComment.styled.ts
+++ b/src/pages/Detail/components/ExpectComment/ExpectComment.styled.ts
@@ -120,6 +120,7 @@ export const BannerFirst = styled.img`
   height: 7rem;
 
   cursor: pointer;
+  display: block;
 `;
 
 export const BannerSecond = styled.img`
@@ -127,4 +128,5 @@ export const BannerSecond = styled.img`
   height: 5.1rem;
 
   cursor: pointer;
+  display: block;
 `;

--- a/src/pages/Detail/components/Info/Info.styled.ts
+++ b/src/pages/Detail/components/Info/Info.styled.ts
@@ -65,9 +65,11 @@ export const ShowSecondImg = styled.img`
 export const BannerFirstImg = styled.img`
   width: 37.5rem;
   height: 4.8rem;
+  display: block;
 `;
 
 export const BannerSecondImg = styled.img`
   width: 37.5rem;
   height: 6.6rem;
+  display: block;
 `;

--- a/src/pages/Detail/components/Info/Info.tsx
+++ b/src/pages/Detail/components/Info/Info.tsx
@@ -19,8 +19,8 @@ const Info = () => {
           <S.ShowSecondImg src={DETAIL_INFO.showImg2} />
         </S.ImgLayout>
       </S.InfoWrapper>
-      <S.BannerFirstImg src={DETAIL_INFO.bannerImg1} />
-      <S.BannerSecondImg src={DETAIL_INFO.bannerImg2} />
+      <S.BannerFirstImg src={DETAIL_INFO.bannerImg2} />
+      <S.BannerSecondImg src={DETAIL_INFO.bannerImg1} />
     </>
   );
 };

--- a/src/pages/Detail/components/ProductInfo/ProductInfo.styled.ts
+++ b/src/pages/Detail/components/ProductInfo/ProductInfo.styled.ts
@@ -25,4 +25,5 @@ export const TableImg = styled.img`
 export const Banner = styled.img`
   width: 37.5rem;
   height: 7rem;
+  display: block;
 `;

--- a/src/pages/Detail/components/ShowPoster/ShowPoster.styled.ts
+++ b/src/pages/Detail/components/ShowPoster/ShowPoster.styled.ts
@@ -8,3 +8,9 @@ export const Poster = styled.img`
   width: 35.5rem;
   height: 49.7rem;
 `;
+
+export const Banner = styled.img`
+  width: 37.5rem;
+  height: 7rem;
+  display: block;
+`;

--- a/src/pages/Detail/components/ShowPoster/ShowPoster.tsx
+++ b/src/pages/Detail/components/ShowPoster/ShowPoster.tsx
@@ -1,11 +1,15 @@
 import * as S from "./ShowPoster.styled";
 import image from "/src/assets/images/poster.png";
+import banner from "/src/assets/images/banner2.png";
 
 const ShowPoster = () => {
   return (
-    <S.PosterWrapper>
-      <S.Poster src={image} />
-    </S.PosterWrapper>
+    <>
+      <S.PosterWrapper>
+        <S.Poster src={image} />
+      </S.PosterWrapper>
+      <S.Banner src={banner} />
+    </>
   );
 };
 


### PR DESCRIPTION
### ✨ 해당 이슈 번호

resolved #72 

### 🌱 작업 내용

- [x] 광고 이미지 사이 공백 제거


### ✅ PR Point
```tsx
export const BannerFirstImg = styled.img`
  width: 37.5rem;
  height: 4.8rem;
  display: block;
`;

export const BannerSecondImg = styled.img`
  width: 37.5rem;
  height: 6.6rem;
  display: block;
`;

```
기존 이미지 코드에 `display: block;` 속성 추가


### 🌱 Trouble Shooting
### 이미지 사이 공백 제거

<img width="423" alt="스크린샷 2024-05-22 오후 5 47 32" src="https://github.com/NOWSOPT-CDSP-WEB-7/YES24-WEB-CLIENT/assets/96781926/758de54b-f5d1-4fb2-9dfa-24bd55bdef00">

- 사진과 같이 이미지의 가로폭은 꽉차있는데 세로가 저절로 gap이 생기는 문제가 있었습니다
- 해당 이미지 태그 스타일에`display: block`을 적용해주면서 해결할 수 있었어요
- img 태그가 인라인 요소이기 때문에 블록 요소와 달리 가상의 기준선을 가지고 있어서 발생한 문제라고 합니다! 따라서 block으로 display 속성을 바꿔주거나, `vertical-align`의 값을 top이나 bottom으로 지정해주는 방식으로 해결할 수 있다고 합니다 (vertical-align의 기본 값은 baseline)


### 👀 스크린샷 (선택)

<img width="389" alt="스크린샷 2024-05-22 오후 5 49 09" src="https://github.com/NOWSOPT-CDSP-WEB-7/YES24-WEB-CLIENT/assets/96781926/898a0be1-ac8a-49f0-8ddd-c380869d2638">


### 📚 Reference

- [구현에 참고한 링크](https://sambalim.tistory.com/147) 