### PR TITLE
[Feat] 검색 결과들의 장르에 따라 필터 개수 변경

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ dist-ssr
 *.sln
 *.sw?
 .env
+.env.local
 
 #dermy-data
 /public/data/search-result.json

--- a/src/apis/SearchApi/getSearchResult.ts
+++ b/src/apis/SearchApi/getSearchResult.ts
@@ -1,0 +1,17 @@
+import axios from "axios";
+
+export const getSearchResult = async (input: string) => {
+  try {
+    const response = await axios.get(
+      `${import.meta.env.VITE_BASE_URL}/runshow/search/?query=${input}`,
+      {
+        headers: {
+          "Content-Type": "application/json",
+        },
+      }
+    );
+    return response.data.data;
+  } catch (error) {
+    console.log(error);
+  }
+};

--- a/src/apis/SearchApi/getSearchResult.ts
+++ b/src/apis/SearchApi/getSearchResult.ts
@@ -3,7 +3,8 @@ import axios from "axios";
 export const getSearchResult = async (input: string) => {
   try {
     const response = await axios.get(
-      `${import.meta.env.VITE_BASE_URL}/runshow/search/?query=${input}`,
+      // `${import.meta.env.VITE_BASE_URL}/runshow/search/?query=${input}`,
+      "/data/search-result.json",
       {
         headers: {
           "Content-Type": "application/json",

--- a/src/apis/SearchApi/getSearchResult.ts
+++ b/src/apis/SearchApi/getSearchResult.ts
@@ -3,8 +3,7 @@ import axios from "axios";
 export const getSearchResult = async (input: string) => {
   try {
     const response = await axios.get(
-      // `${import.meta.env.VITE_BASE_URL}runshow/search?query=${input}`,
-      "/data/search-result.json",
+      `${import.meta.env.VITE_BASE_URL}runshow/search?query=${input}`,
       {
         headers: {
           "Content-Type": "application/json",

--- a/src/components/commons/SearchedShow/SearchedShow.tsx
+++ b/src/components/commons/SearchedShow/SearchedShow.tsx
@@ -1,6 +1,18 @@
 import * as S from "./SearchedShow.styled";
 import showImg from "../../../assets/images/show.png";
-const SearchedShow = () => {
+
+interface SearchResultPropTypes {
+  id: number;
+  title: string;
+  period: string;
+  location: string;
+  place: string;
+  genre: string;
+  image: string;
+}
+
+const SearchedShow = ({ show }: { show: SearchResultPropTypes }) => {
+  const { title, image, location, period, place } = show;
   return (
     <>
       <S.ShowWrapper>
@@ -17,10 +29,10 @@ const SearchedShow = () => {
               단독
             </S.StatusBtn>
           </S.ShowStatusBtns>
-          <S.Title>[울산] 뮤지컬 [레베카] 10주년 기념 공연 앙코르</S.Title>
+          <S.Title>{`[${location}] ${title}`}</S.Title>
           <S.PeriodAndPlace>
-            <S.Period>2024.06.13 ~ 2024.04.14</S.Period>
-            <S.Place>공연 장소</S.Place>
+            <S.Period>{period}</S.Period>
+            <S.Place>{place}</S.Place>
           </S.PeriodAndPlace>
         </S.ShowRightSec>
       </S.ShowWrapper>

--- a/src/components/commons/SearchedShow/SearchedShow.tsx
+++ b/src/components/commons/SearchedShow/SearchedShow.tsx
@@ -1,5 +1,4 @@
 import * as S from "./SearchedShow.styled";
-import showImg from "../../../assets/images/show.png";
 
 interface SearchResultPropTypes {
   id: number;
@@ -16,7 +15,7 @@ const SearchedShow = ({ show }: { show: SearchResultPropTypes }) => {
   return (
     <>
       <S.ShowWrapper>
-        <S.ShowImg src={showImg} />
+        <S.ShowImg src={image} />
         <S.ShowRightSec>
           <S.ShowStatusBtns>
             <S.StatusBtn color={"Text_01"} backcolor={"UI_02"}>

--- a/src/hooks/useChangeInput.ts
+++ b/src/hooks/useChangeInput.ts
@@ -7,7 +7,7 @@ const useChangeInput = () => {
     setInput(e.target.value);
   };
 
-  return { input, handleInputChange };
+  return { input, setInput, handleInputChange };
 };
 
 export default useChangeInput;

--- a/src/pages/Search/components/SearchBar/SearchBar.tsx
+++ b/src/pages/Search/components/SearchBar/SearchBar.tsx
@@ -2,20 +2,40 @@ import * as S from "./SearchBar.styled.ts";
 import { IcSearch, IcCancel } from "../../../../assets/icons";
 import useChangeInput from "../../../../hooks/useChangeInput.ts";
 import SearchList from "../SearchList/SearchList.tsx";
+import { useNavigate } from "react-router-dom";
 
 const SearchBar = () => {
   const { input, handleInputChange } = useChangeInput();
+  const navigate = useNavigate();
+  const handleSearchClick = async () => {
+    if (input.trim().length === 0) {
+      return;
+    }
+
+    localStorage.setItem("searchWord", input);
+
+    navigate("list");
+  };
+  const handleKeyPress = (e: { key: string }) => {
+    if (e.key === "Enter") {
+      handleSearchClick();
+    }
+  };
   return (
     <S.SearchBarAndListWrapper>
       <S.SearchBarContainer>
         <S.SearchBarWrapper>
-          <S.SearchBarInput placeholder="검색어를 입력해주세요" onChange={handleInputChange} />
+          <S.SearchBarInput
+            placeholder="검색어를 입력해주세요"
+            onChange={handleInputChange}
+            onKeyDown={handleKeyPress}
+          />
           {input.trim().length !== 0 && (
             <S.CancelBtn>
               <IcCancel />
             </S.CancelBtn>
           )}
-          <S.SearchBtn>
+          <S.SearchBtn onClick={handleSearchClick}>
             <IcSearch />
           </S.SearchBtn>
         </S.SearchBarWrapper>

--- a/src/pages/Search/components/SearchBar/SearchBar.tsx
+++ b/src/pages/Search/components/SearchBar/SearchBar.tsx
@@ -2,11 +2,25 @@ import * as S from "./SearchBar.styled.ts";
 import { IcSearch, IcCancel } from "../../../../assets/icons";
 import useChangeInput from "../../../../hooks/useChangeInput.ts";
 import SearchList from "../SearchList/SearchList.tsx";
-import { useNavigate } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
+import { useEffect } from "react";
 
 const SearchBar = () => {
-  const { input, handleInputChange } = useChangeInput();
+  const { input, setInput, handleInputChange } = useChangeInput();
   const navigate = useNavigate();
+  const location = useLocation();
+
+  useEffect(() => {
+    const savedInputWord = localStorage.getItem("searchWord");
+    if (savedInputWord) {
+      setInput(savedInputWord);
+    }
+    if (location.pathname === "/search") {
+      localStorage.removeItem("searchWord");
+      setInput("");
+    }
+  }, [setInput, location.pathname]);
+
   const handleSearchClick = async () => {
     if (input.trim().length === 0) {
       return;
@@ -29,6 +43,7 @@ const SearchBar = () => {
             placeholder="검색어를 입력해주세요"
             onChange={handleInputChange}
             onKeyDown={handleKeyPress}
+            value={input}
           />
           {input.trim().length !== 0 && (
             <S.CancelBtn>
@@ -40,7 +55,7 @@ const SearchBar = () => {
           </S.SearchBtn>
         </S.SearchBarWrapper>
       </S.SearchBarContainer>
-      {input && <SearchList input={input} />}
+      {location.pathname === "/search" && input && <SearchList input={input} />}
     </S.SearchBarAndListWrapper>
   );
 };

--- a/src/pages/SearchListPage/SearchListPage.styled.ts
+++ b/src/pages/SearchListPage/SearchListPage.styled.ts
@@ -1,5 +1,14 @@
 import styled from "styled-components";
 
-export const PageWrapper = styled.section`
-  height: 100rem;
+export const ListPageWrapper = styled.section`
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  min-height: 100dvh;
+`;
+export const FiltersWrapper = styled.section`
+  /* height: 100rem; */
+`;
+export const FooterWrapper = styled.section`
+  margin-top: auto;
 `;

--- a/src/pages/SearchListPage/SearchListPage.styled.ts
+++ b/src/pages/SearchListPage/SearchListPage.styled.ts
@@ -6,9 +6,6 @@ export const ListPageWrapper = styled.section`
   width: 100%;
   min-height: 100dvh;
 `;
-export const FiltersWrapper = styled.section`
-  /* height: 100rem; */
-`;
 export const FooterWrapper = styled.section`
   margin-top: auto;
 `;

--- a/src/pages/SearchListPage/SearchListPage.tsx
+++ b/src/pages/SearchListPage/SearchListPage.tsx
@@ -1,17 +1,23 @@
+import Footer from "@components/commons/Footer/Footer";
 import SearchBar from "../Search/components/SearchBar/SearchBar";
 import SearchHeader from "../Search/components/SearchHeader/SearchHeader";
+import FilteredResultList from "./components/FilteredResultList/FilteredResultList";
 import Filters from "./components/Filters/Filters";
 import * as S from "./SearchListPage.styled";
 
 const SearchListPage = () => {
   return (
-    <>
+    <S.ListPageWrapper>
       <SearchHeader />
       <SearchBar />
-      <S.PageWrapper>
+      <S.FiltersWrapper>
         <Filters />
-      </S.PageWrapper>
-    </>
+      </S.FiltersWrapper>
+      <FilteredResultList />
+      <S.FooterWrapper>
+        <Footer />
+      </S.FooterWrapper>
+    </S.ListPageWrapper>
   );
 };
 

--- a/src/pages/SearchListPage/SearchListPage.tsx
+++ b/src/pages/SearchListPage/SearchListPage.tsx
@@ -1,19 +1,15 @@
 import Footer from "@components/commons/Footer/Footer";
 import SearchBar from "../Search/components/SearchBar/SearchBar";
 import SearchHeader from "../Search/components/SearchHeader/SearchHeader";
-import FilteredResultList from "./components/FilteredResultList/FilteredResultList";
-import Filters from "./components/Filters/Filters";
 import * as S from "./SearchListPage.styled";
+import FiltersAndResult from "./components/FiltersAndResult/FiltersAndResult";
 
 const SearchListPage = () => {
   return (
     <S.ListPageWrapper>
       <SearchHeader />
       <SearchBar />
-      <S.FiltersWrapper>
-        <Filters />
-      </S.FiltersWrapper>
-      <FilteredResultList />
+      <FiltersAndResult />
       <S.FooterWrapper>
         <Footer />
       </S.FooterWrapper>

--- a/src/pages/SearchListPage/components/FilteredResultList/FilteredResultList.styled.ts
+++ b/src/pages/SearchListPage/components/FilteredResultList/FilteredResultList.styled.ts
@@ -1,0 +1,5 @@
+import styled from "styled-components";
+
+export const ResultListWrapper = styled.section`
+  background-color: pink;
+`;

--- a/src/pages/SearchListPage/components/FilteredResultList/FilteredResultList.styled.ts
+++ b/src/pages/SearchListPage/components/FilteredResultList/FilteredResultList.styled.ts
@@ -1,5 +1,4 @@
 import styled from "styled-components";
 
 export const ResultListWrapper = styled.section`
-  background-color: pink;
 `;

--- a/src/pages/SearchListPage/components/FilteredResultList/FilteredResultList.tsx
+++ b/src/pages/SearchListPage/components/FilteredResultList/FilteredResultList.tsx
@@ -1,7 +1,27 @@
+import SearchedShow from "@components/commons/SearchedShow/SearchedShow";
 import * as S from "./FilteredResultList.styled";
 
-const FilteredResultList = () => {
-  return <S.ResultListWrapper>1</S.ResultListWrapper>;
+interface SearchResultPropTypes {
+  id: number;
+  title: string;
+  period: string;
+  location: string;
+  place: string;
+  genre: string;
+  image: string;
+}
+interface ResultListProps {
+  searchResult: SearchResultPropTypes[];
+}
+
+const FilteredResultList = ({ searchResult }: ResultListProps) => {
+  return (
+    <S.ResultListWrapper>
+      {searchResult.map((show) => (
+        <SearchedShow show={show} key={show.id} />
+      ))}
+    </S.ResultListWrapper>
+  );
 };
 
 export default FilteredResultList;

--- a/src/pages/SearchListPage/components/FilteredResultList/FilteredResultList.tsx
+++ b/src/pages/SearchListPage/components/FilteredResultList/FilteredResultList.tsx
@@ -1,0 +1,7 @@
+import * as S from "./FilteredResultList.styled";
+
+const FilteredResultList = () => {
+  return <S.ResultListWrapper>1</S.ResultListWrapper>;
+};
+
+export default FilteredResultList;

--- a/src/pages/SearchListPage/components/Filters/Filters.styled.ts
+++ b/src/pages/SearchListPage/components/Filters/Filters.styled.ts
@@ -57,7 +57,9 @@ export const SelectedSort = styled.span`
   padding: 0.5rem;
 
   color: ${({ theme }) => theme.colors.Text_01};
+
   ${({ theme }) => theme.fonts.sub_12pt};
+  cursor: pointer;
 `;
 export const DropdownBtn = styled.button`
   display: flex;
@@ -87,6 +89,7 @@ export const SortItem = styled.li`
   white-space: nowrap;
 
   ${({ theme }) => theme.fonts.dropdown_11pt};
+  cursor: pointer;
 
   &:hover {
     color: ${({ theme }) => theme.colors.Secondary_orange};

--- a/src/pages/SearchListPage/components/Filters/Filters.tsx
+++ b/src/pages/SearchListPage/components/Filters/Filters.tsx
@@ -32,14 +32,14 @@ const genreToFilter: GenreToFilterPropTypes = {
 };
 
 const Filters = ({ genres }: FiltersPropTypes) => {
-  const genreCounts = genres.reduce<{ [key: string]: number }>((acc, genre) => {
+  const genreCounts = genres.reduce<{ [key: string]: number }>((genreCount, genre) => {
     const filterNames = genreToFilter[genre];
     if (filterNames) {
       filterNames.forEach((filterName) => {
-        acc[filterName] = (acc[filterName] || 0) + 1;
+        genreCount[filterName] = (genreCount[filterName] || 0) + 1;
       });
     }
-    return acc;
+    return genreCount;
   }, {});
 
   const totalCount = genres.length;

--- a/src/pages/SearchListPage/components/Filters/Filters.tsx
+++ b/src/pages/SearchListPage/components/Filters/Filters.tsx
@@ -4,8 +4,17 @@ import { IcDropDown } from "../../../../assets/icons";
 
 const options = ["정확도순", "공연임박순", "판매많은순"];
 
+interface FixedFilterPropTypes {
+  name: string;
+}
+interface GenreToFilterPropTypes {
+  [key: string]: string[];
+}
+interface FiltersPropTypes {
+  genres: string[];
+}
 // 고정된 필터 이름 배열
-const fixedFilters = [
+const fixedFilters: FixedFilterPropTypes[] = [
   { name: "전체" },
   { name: "뮤지컬/연극" },
   { name: "클래식/무용" },
@@ -13,7 +22,7 @@ const fixedFilters = [
 ];
 
 // 각 장르가 어떤 필터에 속하는지 정의
-const genreToFilter = {
+const genreToFilter: GenreToFilterPropTypes = {
   musical: ["뮤지컬/연극"],
   theater: ["뮤지컬/연극"],
   classic: ["클래식/무용"],
@@ -22,8 +31,8 @@ const genreToFilter = {
   event: ["전시/행사"],
 };
 
-const Filters = ({ genres }) => {
-  const genreCounts = genres.reduce((acc, genre) => {
+const Filters = ({ genres }: FiltersPropTypes) => {
+  const genreCounts = genres.reduce<{ [key: string]: number }>((acc, genre) => {
     const filterNames = genreToFilter[genre];
     if (filterNames) {
       filterNames.forEach((filterName) => {

--- a/src/pages/SearchListPage/components/Filters/Filters.tsx
+++ b/src/pages/SearchListPage/components/Filters/Filters.tsx
@@ -5,7 +5,7 @@ import { IcDropDown } from "../../../../assets/icons";
 const filters = ["전체(136)", "뮤지컬/연극(116)", "클래식/무용(5)", "전시/행사(15)"];
 const options = ["정확도순", "공연임박순", "판매많은순"];
 const Filters = () => {
-  const [activeFilter, setActiveFilter] = useState<string | null>(null);
+  const [activeFilter, setActiveFilter] = useState<string | null>(filters[0]);
   const [selectedOption, setSelectedOption] = useState<string>(options[0]);
   const [isOpen, setIsOpen] = useState<boolean>(false);
 
@@ -19,7 +19,6 @@ const Filters = () => {
     setSelectedOption(option);
     setIsOpen(false);
   };
-  console.log(isOpen);
   return (
     <>
       <S.FiltersWrapper>

--- a/src/pages/SearchListPage/components/Filters/Filters.tsx
+++ b/src/pages/SearchListPage/components/Filters/Filters.tsx
@@ -1,13 +1,54 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import * as S from "./Filters.styled";
 import { IcDropDown } from "../../../../assets/icons";
 
-const filters = ["전체(136)", "뮤지컬/연극(116)", "클래식/무용(5)", "전시/행사(15)"];
 const options = ["정확도순", "공연임박순", "판매많은순"];
-const Filters = () => {
-  const [activeFilter, setActiveFilter] = useState<string | null>(filters[0]);
+
+// 고정된 필터 이름 배열
+const fixedFilters = [
+  { name: "전체" },
+  { name: "뮤지컬/연극" },
+  { name: "클래식/무용" },
+  { name: "전시/행사" },
+];
+
+// 각 장르가 어떤 필터에 속하는지 정의
+const genreToFilter = {
+  musical: ["뮤지컬/연극"],
+  theater: ["뮤지컬/연극"],
+  classic: ["클래식/무용"],
+  dancing: ["클래식/무용"],
+  exhibition: ["전시/행사"],
+  event: ["전시/행사"],
+};
+
+const Filters = ({ genres }) => {
+  const genreCounts = genres.reduce((acc, genre) => {
+    const filterNames = genreToFilter[genre];
+    if (filterNames) {
+      filterNames.forEach((filterName) => {
+        acc[filterName] = (acc[filterName] || 0) + 1;
+      });
+    }
+    return acc;
+  }, {});
+
+  const totalCount = genres.length;
+
+  const filters = fixedFilters.map((filter) => {
+    const count = filter.name === "전체" ? totalCount : genreCounts[filter.name] || 0;
+    return `${filter.name}(${count})`;
+  });
+
+  const [activeFilter, setActiveFilter] = useState<string | null>(null);
   const [selectedOption, setSelectedOption] = useState<string>(options[0]);
   const [isOpen, setIsOpen] = useState<boolean>(false);
+
+  useEffect(() => {
+    if (filters.length > 0) {
+      setActiveFilter(filters[0]);
+    }
+  }, [filters]);
 
   const handleFilterClick = (filter: string) => {
     setActiveFilter(filter);
@@ -19,6 +60,7 @@ const Filters = () => {
     setSelectedOption(option);
     setIsOpen(false);
   };
+
   return (
     <>
       <S.FiltersWrapper>
@@ -32,7 +74,7 @@ const Filters = () => {
         })}
       </S.FiltersWrapper>
       <S.FilterResultAndSort>
-        <S.FilterResult>총 116개의 검색 결과가 나왔습니다.</S.FilterResult>
+        <S.FilterResult>총 {totalCount}개의 검색 결과가 나왔습니다.</S.FilterResult>
         <S.SortBox>
           <S.SelectSortWrapper>
             <S.SelectedSort>{selectedOption}</S.SelectedSort>

--- a/src/pages/SearchListPage/components/Filters/Filters.tsx
+++ b/src/pages/SearchListPage/components/Filters/Filters.tsx
@@ -76,9 +76,9 @@ const Filters = ({ genres }) => {
       <S.FilterResultAndSort>
         <S.FilterResult>총 {totalCount}개의 검색 결과가 나왔습니다.</S.FilterResult>
         <S.SortBox>
-          <S.SelectSortWrapper>
+          <S.SelectSortWrapper onClick={toggleDropdown}>
             <S.SelectedSort>{selectedOption}</S.SelectedSort>
-            <S.DropdownBtn onClick={toggleDropdown}>
+            <S.DropdownBtn>
               <IcDropDown />
             </S.DropdownBtn>
           </S.SelectSortWrapper>

--- a/src/pages/SearchListPage/components/FiltersAndResult/FiltersAndResult.tsx
+++ b/src/pages/SearchListPage/components/FiltersAndResult/FiltersAndResult.tsx
@@ -1,0 +1,37 @@
+import { getSearchResult } from "@apis/SearchApi/getSearchResult";
+import FilteredResultList from "../FilteredResultList/FilteredResultList";
+import Filters from "../Filters/Filters";
+import { useEffect, useState } from "react";
+
+interface SearchResultPropTypes {
+  id: number;
+  title: string;
+  period: string;
+  location: string;
+  place: string;
+  genre: string;
+  image: string;
+}
+
+const FiltersAndResult = () => {
+  const [searchResult, setSearchResult] = useState<SearchResultPropTypes[]>([]);
+  useEffect(() => {
+    const searchWord = localStorage.getItem("searchWord");
+    if (searchWord) {
+      //   setInput(searchWord);
+      fetchSearchResults(searchWord);
+    }
+  }, []);
+  const fetchSearchResults = async (word: string) => {
+    const result = await getSearchResult(word);
+    setSearchResult(result);
+  };
+  return (
+    <>
+      <Filters />
+      <FilteredResultList searchResult={searchResult} />
+    </>
+  );
+};
+
+export default FiltersAndResult;

--- a/src/pages/SearchListPage/components/FiltersAndResult/FiltersAndResult.tsx
+++ b/src/pages/SearchListPage/components/FiltersAndResult/FiltersAndResult.tsx
@@ -15,6 +15,8 @@ interface SearchResultPropTypes {
 
 const FiltersAndResult = () => {
   const [searchResult, setSearchResult] = useState<SearchResultPropTypes[]>([]);
+  const [genres, setGenres] = useState<string[]>([]);
+
   useEffect(() => {
     const searchWord = localStorage.getItem("searchWord");
     if (searchWord) {
@@ -24,10 +26,13 @@ const FiltersAndResult = () => {
   const fetchSearchResults = async (word: string) => {
     const result = await getSearchResult(word);
     setSearchResult(result);
+
+    const extractedGenres = result.map((item) => item.genre);
+    setGenres(extractedGenres);
   };
   return (
     <>
-      <Filters />
+      <Filters genres={genres} />
       <FilteredResultList searchResult={searchResult} />
     </>
   );

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,8 @@
       "@styles/*": ["src/styles/*"],
       "@constants/*": ["src/constants/*"],
       "@hooks/*": ["src/hooks/*"],
-      "@utils/*": ["src/utils/*"]
+      "@utils/*": ["src/utils/*"],
+      "@apis/*": ["src/apis/*"]
     },
 
     "target": "ES2020",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -14,6 +14,7 @@ export default defineConfig({
       { find: "@constants", replacement: "/src/constants" },
       { find: "@hooks", replacement: "/src/hooks" },
       { find: "@utils", replacement: "/src/utils" },
+      { find: "@apis", replacement: "/src/apis" },
     ],
   },
 });


### PR DESCRIPTION
### ✨ 해당 이슈 번호

resolved #76 

### 🌱 작업 내용

- [x] ~ 검색 결과를 받아와 장르만 담은 배열을 따로 빼서 filters 컴포넌트로 전달
- [x] ~ 전달받은 배열에서 각 장르별 개수를 세어서 화면에 표기


### ✅ PR Point
- ~ 부분 이렇게 구현했어요, 피드백 부탁해요!
- 각 장르가 속하는 필터를 지정해놓고 이를 반복문을 통해 개수를 증가시켜줍니다.


### 🌱 Trouble Shooting
- 개발 중 겪은 트러블 정리!


### 👀 스크린샷 (선택)
<img width="457" alt="스크린샷 2024-05-22 오후 10 25 30" src="https://github.com/NOWSOPT-CDSP-WEB-7/YES24-WEB-CLIENT/assets/101498590/250b146e-945c-431f-937b-bf406bb064be">


### 📚 Reference
