### PR TITLE
[Feat] 최근검색어 가져오기 및 삭제하기

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ dist-ssr
 *.sln
 *.sw?
 .env
+.env.local
 
 #dermy-data
 /public/data/search-result.json

--- a/src/apis/SearchApi/getSearchResult.ts
+++ b/src/apis/SearchApi/getSearchResult.ts
@@ -1,0 +1,17 @@
+import axios from "axios";
+
+export const getSearchResult = async (input: string) => {
+  try {
+    const response = await axios.get(
+      `${import.meta.env.VITE_BASE_URL}/runshow/search/?query=${input}`,
+      {
+        headers: {
+          "Content-Type": "application/json",
+        },
+      }
+    );
+    return response.data.data;
+  } catch (error) {
+    console.log(error);
+  }
+};

--- a/src/apis/SearchApi/getSearchResult.ts
+++ b/src/apis/SearchApi/getSearchResult.ts
@@ -3,7 +3,8 @@ import axios from "axios";
 export const getSearchResult = async (input: string) => {
   try {
     const response = await axios.get(
-      `${import.meta.env.VITE_BASE_URL}/runshow/search/?query=${input}`,
+      // `${import.meta.env.VITE_BASE_URL}/runshow/search/?query=${input}`,
+      "/data/search-result.json",
       {
         headers: {
           "Content-Type": "application/json",

--- a/src/components/commons/DeleteAllBtn/DeleteAllBtn.tsx
+++ b/src/components/commons/DeleteAllBtn/DeleteAllBtn.tsx
@@ -1,7 +1,12 @@
 import * as S from "./DeleteAllBtn.styled";
-const DeleteAllBtn = () => {
+
+interface DeleteAllPropTypes {
+  onClick: () => void;
+}
+
+const DeleteAllBtn = ({ onClick }: DeleteAllPropTypes) => {
   return (
-    <S.BtnContainer>
+    <S.BtnContainer onClick={onClick}>
       <S.DeleteBtn>전체삭제</S.DeleteBtn>
     </S.BtnContainer>
   );

--- a/src/components/commons/DeleteAllBtn/DeleteAllBtn.tsx
+++ b/src/components/commons/DeleteAllBtn/DeleteAllBtn.tsx
@@ -1,12 +1,12 @@
 import * as S from "./DeleteAllBtn.styled";
 
 interface DeleteAllPropTypes {
-  onClick: () => void;
+  handleDelete: () => void;
 }
 
-const DeleteAllBtn = ({ onClick }: DeleteAllPropTypes) => {
+const DeleteAllBtn = ({ handleDelete }: DeleteAllPropTypes) => {
   return (
-    <S.BtnContainer onClick={onClick}>
+    <S.BtnContainer onClick={handleDelete}>
       <S.DeleteBtn>전체삭제</S.DeleteBtn>
     </S.BtnContainer>
   );

--- a/src/components/commons/SearchedShow/SearchedShow.tsx
+++ b/src/components/commons/SearchedShow/SearchedShow.tsx
@@ -1,6 +1,18 @@
 import * as S from "./SearchedShow.styled";
 import showImg from "../../../assets/images/show.png";
-const SearchedShow = () => {
+
+interface SearchResultPropTypes {
+  id: number;
+  title: string;
+  period: string;
+  location: string;
+  place: string;
+  genre: string;
+  image: string;
+}
+
+const SearchedShow = ({ show }: { show: SearchResultPropTypes }) => {
+  const { title, image, location, period, place } = show;
   return (
     <>
       <S.ShowWrapper>
@@ -17,10 +29,10 @@ const SearchedShow = () => {
               단독
             </S.StatusBtn>
           </S.ShowStatusBtns>
-          <S.Title>[울산] 뮤지컬 [레베카] 10주년 기념 공연 앙코르</S.Title>
+          <S.Title>{`[${location}] ${title}`}</S.Title>
           <S.PeriodAndPlace>
-            <S.Period>2024.06.13 ~ 2024.04.14</S.Period>
-            <S.Place>공연 장소</S.Place>
+            <S.Period>{period}</S.Period>
+            <S.Place>{place}</S.Place>
           </S.PeriodAndPlace>
         </S.ShowRightSec>
       </S.ShowWrapper>

--- a/src/hooks/useChangeInput.ts
+++ b/src/hooks/useChangeInput.ts
@@ -7,7 +7,7 @@ const useChangeInput = () => {
     setInput(e.target.value);
   };
 
-  return { input, handleInputChange };
+  return { input, setInput, handleInputChange };
 };
 
 export default useChangeInput;

--- a/src/pages/Search/components/RecentWord/RecentWord.tsx
+++ b/src/pages/Search/components/RecentWord/RecentWord.tsx
@@ -3,13 +3,17 @@ import { IcCancel } from "../../../../assets/icons";
 
 interface WordPropTypes {
   word: string;
+  onDelete: (word: string) => void;
 }
 
-const RecentWord = ({ word }: WordPropTypes) => {
+const RecentWord = ({ word, onDelete }: WordPropTypes) => {
+  const handleWordDelete = () => {
+    onDelete(word);
+  };
   return (
     <S.WordWrapper>
       <S.Word>{word}</S.Word>
-      <S.CancelBtn>
+      <S.CancelBtn onClick={handleWordDelete}>
         <IcCancel />
       </S.CancelBtn>
     </S.WordWrapper>

--- a/src/pages/Search/components/RecentWords/RecentWords.styled.ts
+++ b/src/pages/Search/components/RecentWords/RecentWords.styled.ts
@@ -3,5 +3,12 @@ import styled from "styled-components";
 export const Wrapper = styled.section`
   width: 100%;
   height: auto;
+`;
+export const NoRecentWords = styled.span`
+  margin-top: 4.4rem;
 
+  color: ${({ theme }) => theme.colors.Text_02};
+  text-align: center;
+
+  ${({ theme }) => theme.fonts.sub_14pt};
 `;

--- a/src/pages/Search/components/RecentWords/RecentWords.tsx
+++ b/src/pages/Search/components/RecentWords/RecentWords.tsx
@@ -38,7 +38,7 @@ const RecentWords = () => {
           </div>
         )}
       </S.Wrapper>
-      <DeleteAllBtn onClick={handleDeleteAll} />
+      <DeleteAllBtn handleDelete={handleDeleteAll} />
     </>
   );
 };

--- a/src/pages/Search/components/RecentWords/RecentWords.tsx
+++ b/src/pages/Search/components/RecentWords/RecentWords.tsx
@@ -1,12 +1,23 @@
 import * as S from "./RecentWords.styled";
 import RecentWord from "../RecentWord/RecentWord";
 import DeleteAllBtn from "@components/commons/DeleteAllBtn/DeleteAllBtn";
+import { useEffect, useState } from "react";
 
 const RecentWords = () => {
-  const words: string[] = ["레베카", "울산", "서울"];
+  const [words, setWords] = useState([]);
+  useEffect(() => {
+    const recentWordsList = localStorage.getItem("recentWordsList");
+    if (recentWordsList) {
+      const parsedWords = JSON.parse(recentWordsList);
+      setWords(parsedWords);
+    }
+  }, []);
   if (words.length === 0) {
     return <div>최근 검색어가 없습니다.</div>;
   }
+  const handleDeleteAll = () => {
+    localStorage.removeItem("recentWordsList");
+  };
   return (
     <>
       <S.Wrapper>
@@ -18,7 +29,7 @@ const RecentWords = () => {
           </div>
         )}
       </S.Wrapper>
-      <DeleteAllBtn />
+      <DeleteAllBtn onClick={handleDeleteAll} />
     </>
   );
 };

--- a/src/pages/Search/components/RecentWords/RecentWords.tsx
+++ b/src/pages/Search/components/RecentWords/RecentWords.tsx
@@ -16,7 +16,7 @@ const RecentWords = () => {
     }
   };
   if (words.length === 0) {
-    return <div>최근 검색어가 없습니다.</div>;
+    return <S.NoRecentWords>최근 검색어가 없습니다</S.NoRecentWords>;
   }
   const handleDeleteAll = () => {
     localStorage.removeItem("recentWordsList");

--- a/src/pages/Search/components/RecentWords/RecentWords.tsx
+++ b/src/pages/Search/components/RecentWords/RecentWords.tsx
@@ -22,13 +22,18 @@ const RecentWords = () => {
     localStorage.removeItem("recentWordsList");
     setWords([]);
   };
+  const handleDeleteWord = (word: string) => {
+    const updatedWords = words.filter((w) => w !== word);
+    localStorage.setItem("recentWordsList", JSON.stringify(updatedWords));
+    setWords(updatedWords);
+  };
   return (
     <>
       <S.Wrapper>
         {words && (
           <div>
             {words.map((word, i) => {
-              return <RecentWord key={i} word={word} />;
+              return <RecentWord key={i} word={word} onDelete={handleDeleteWord} />;
             })}
           </div>
         )}

--- a/src/pages/Search/components/RecentWords/RecentWords.tsx
+++ b/src/pages/Search/components/RecentWords/RecentWords.tsx
@@ -6,17 +6,21 @@ import { useEffect, useState } from "react";
 const RecentWords = () => {
   const [words, setWords] = useState([]);
   useEffect(() => {
+    getRecentWordsList();
+  }, []);
+  const getRecentWordsList = () => {
     const recentWordsList = localStorage.getItem("recentWordsList");
     if (recentWordsList) {
       const parsedWords = JSON.parse(recentWordsList);
       setWords(parsedWords);
     }
-  }, []);
+  };
   if (words.length === 0) {
     return <div>최근 검색어가 없습니다.</div>;
   }
   const handleDeleteAll = () => {
     localStorage.removeItem("recentWordsList");
+    setWords([]);
   };
   return (
     <>

--- a/src/pages/Search/components/SearchBar/SearchBar.tsx
+++ b/src/pages/Search/components/SearchBar/SearchBar.tsx
@@ -2,20 +2,40 @@ import * as S from "./SearchBar.styled.ts";
 import { IcSearch, IcCancel } from "../../../../assets/icons";
 import useChangeInput from "../../../../hooks/useChangeInput.ts";
 import SearchList from "../SearchList/SearchList.tsx";
+import { useNavigate } from "react-router-dom";
 
 const SearchBar = () => {
   const { input, handleInputChange } = useChangeInput();
+  const navigate = useNavigate();
+  const handleSearchClick = async () => {
+    if (input.trim().length === 0) {
+      return;
+    }
+
+    localStorage.setItem("searchWord", input);
+
+    navigate("list");
+  };
+  const handleKeyPress = (e: { key: string }) => {
+    if (e.key === "Enter") {
+      handleSearchClick();
+    }
+  };
   return (
     <S.SearchBarAndListWrapper>
       <S.SearchBarContainer>
         <S.SearchBarWrapper>
-          <S.SearchBarInput placeholder="검색어를 입력해주세요" onChange={handleInputChange} />
+          <S.SearchBarInput
+            placeholder="검색어를 입력해주세요"
+            onChange={handleInputChange}
+            onKeyDown={handleKeyPress}
+          />
           {input.trim().length !== 0 && (
             <S.CancelBtn>
               <IcCancel />
             </S.CancelBtn>
           )}
-          <S.SearchBtn>
+          <S.SearchBtn onClick={handleSearchClick}>
             <IcSearch />
           </S.SearchBtn>
         </S.SearchBarWrapper>

--- a/src/pages/Search/components/SearchBar/SearchBar.tsx
+++ b/src/pages/Search/components/SearchBar/SearchBar.tsx
@@ -2,11 +2,25 @@ import * as S from "./SearchBar.styled.ts";
 import { IcSearch, IcCancel } from "../../../../assets/icons";
 import useChangeInput from "../../../../hooks/useChangeInput.ts";
 import SearchList from "../SearchList/SearchList.tsx";
-import { useNavigate } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
+import { useEffect } from "react";
 
 const SearchBar = () => {
-  const { input, handleInputChange } = useChangeInput();
+  const { input, setInput, handleInputChange } = useChangeInput();
   const navigate = useNavigate();
+  const location = useLocation();
+
+  useEffect(() => {
+    const savedInputWord = localStorage.getItem("searchWord");
+    if (savedInputWord) {
+      setInput(savedInputWord);
+    }
+    if (location.pathname === "/search") {
+      localStorage.removeItem("searchWord");
+      setInput("");
+    }
+  }, [setInput, location.pathname]);
+
   const handleSearchClick = async () => {
     if (input.trim().length === 0) {
       return;
@@ -29,6 +43,7 @@ const SearchBar = () => {
             placeholder="검색어를 입력해주세요"
             onChange={handleInputChange}
             onKeyDown={handleKeyPress}
+            value={input}
           />
           {input.trim().length !== 0 && (
             <S.CancelBtn>
@@ -40,7 +55,7 @@ const SearchBar = () => {
           </S.SearchBtn>
         </S.SearchBarWrapper>
       </S.SearchBarContainer>
-      {input && <SearchList input={input} />}
+      {location.pathname === "/search" && input && <SearchList input={input} />}
     </S.SearchBarAndListWrapper>
   );
 };

--- a/src/pages/Search/components/SearchBar/SearchBar.tsx
+++ b/src/pages/Search/components/SearchBar/SearchBar.tsx
@@ -3,21 +3,26 @@ import { IcSearch, IcCancel } from "../../../../assets/icons";
 import useChangeInput from "../../../../hooks/useChangeInput.ts";
 import SearchList from "../SearchList/SearchList.tsx";
 import { useLocation, useNavigate } from "react-router-dom";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 
 const SearchBar = () => {
   const { input, setInput, handleInputChange } = useChangeInput();
   const navigate = useNavigate();
   const location = useLocation();
+  const [recentWordsList, setRecentWordsList] = useState<string[]>([]);
 
   useEffect(() => {
     const savedInputWord = localStorage.getItem("searchWord");
+    const savedRecentWordsList = localStorage.getItem("recentWordsList");
     if (savedInputWord) {
       setInput(savedInputWord);
     }
     if (location.pathname === "/search") {
       localStorage.removeItem("searchWord");
       setInput("");
+    }
+    if (savedRecentWordsList) {
+      setRecentWordsList(JSON.parse(savedRecentWordsList));
     }
   }, [setInput, location.pathname]);
 
@@ -27,6 +32,9 @@ const SearchBar = () => {
     }
 
     localStorage.setItem("searchWord", input);
+    const updatedRecentWordsList = [input, ...recentWordsList.filter((word) => word !== input)];
+    setRecentWordsList(updatedRecentWordsList);
+    localStorage.setItem("recentWordsList", JSON.stringify(updatedRecentWordsList));
 
     navigate("list");
   };

--- a/src/pages/Search/components/SearchBar/SearchBar.tsx
+++ b/src/pages/Search/components/SearchBar/SearchBar.tsx
@@ -26,17 +26,23 @@ const SearchBar = () => {
     }
   }, [setInput, location.pathname]);
 
+  const updateRecentWordsList = (newWord: string) => {
+    localStorage.setItem("searchWord", newWord);
+    const updatedRecentWordsList = [newWord, ...recentWordsList.filter((word) => word !== newWord)];
+    setRecentWordsList(updatedRecentWordsList);
+    localStorage.setItem("recentWordsList", JSON.stringify(updatedRecentWordsList));
+  };
+
   const handleSearchClick = async () => {
     if (input.trim().length === 0) {
       return;
     }
 
-    localStorage.setItem("searchWord", input);
-    const updatedRecentWordsList = [input, ...recentWordsList.filter((word) => word !== input)];
-    setRecentWordsList(updatedRecentWordsList);
-    localStorage.setItem("recentWordsList", JSON.stringify(updatedRecentWordsList));
+    updateRecentWordsList(input);
 
-    navigate("list");
+    if (location.pathname === "/search") {
+      navigate("list");
+    }
   };
   const handleKeyPress = (e: { key: string }) => {
     if (e.key === "Enter") {

--- a/src/pages/SearchListPage/SearchListPage.styled.ts
+++ b/src/pages/SearchListPage/SearchListPage.styled.ts
@@ -1,5 +1,14 @@
 import styled from "styled-components";
 
-export const PageWrapper = styled.section`
-  height: 100rem;
+export const ListPageWrapper = styled.section`
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  min-height: 100dvh;
+`;
+export const FiltersWrapper = styled.section`
+  /* height: 100rem; */
+`;
+export const FooterWrapper = styled.section`
+  margin-top: auto;
 `;

--- a/src/pages/SearchListPage/SearchListPage.styled.ts
+++ b/src/pages/SearchListPage/SearchListPage.styled.ts
@@ -6,9 +6,6 @@ export const ListPageWrapper = styled.section`
   width: 100%;
   min-height: 100dvh;
 `;
-export const FiltersWrapper = styled.section`
-  /* height: 100rem; */
-`;
 export const FooterWrapper = styled.section`
   margin-top: auto;
 `;

--- a/src/pages/SearchListPage/SearchListPage.tsx
+++ b/src/pages/SearchListPage/SearchListPage.tsx
@@ -1,17 +1,23 @@
+import Footer from "@components/commons/Footer/Footer";
 import SearchBar from "../Search/components/SearchBar/SearchBar";
 import SearchHeader from "../Search/components/SearchHeader/SearchHeader";
+import FilteredResultList from "./components/FilteredResultList/FilteredResultList";
 import Filters from "./components/Filters/Filters";
 import * as S from "./SearchListPage.styled";
 
 const SearchListPage = () => {
   return (
-    <>
+    <S.ListPageWrapper>
       <SearchHeader />
       <SearchBar />
-      <S.PageWrapper>
+      <S.FiltersWrapper>
         <Filters />
-      </S.PageWrapper>
-    </>
+      </S.FiltersWrapper>
+      <FilteredResultList />
+      <S.FooterWrapper>
+        <Footer />
+      </S.FooterWrapper>
+    </S.ListPageWrapper>
   );
 };
 

--- a/src/pages/SearchListPage/SearchListPage.tsx
+++ b/src/pages/SearchListPage/SearchListPage.tsx
@@ -1,19 +1,15 @@
 import Footer from "@components/commons/Footer/Footer";
 import SearchBar from "../Search/components/SearchBar/SearchBar";
 import SearchHeader from "../Search/components/SearchHeader/SearchHeader";
-import FilteredResultList from "./components/FilteredResultList/FilteredResultList";
-import Filters from "./components/Filters/Filters";
 import * as S from "./SearchListPage.styled";
+import FiltersAndResult from "./components/FiltersAndResult/FiltersAndResult";
 
 const SearchListPage = () => {
   return (
     <S.ListPageWrapper>
       <SearchHeader />
       <SearchBar />
-      <S.FiltersWrapper>
-        <Filters />
-      </S.FiltersWrapper>
-      <FilteredResultList />
+      <FiltersAndResult />
       <S.FooterWrapper>
         <Footer />
       </S.FooterWrapper>

--- a/src/pages/SearchListPage/components/FilteredResultList/FilteredResultList.styled.ts
+++ b/src/pages/SearchListPage/components/FilteredResultList/FilteredResultList.styled.ts
@@ -1,0 +1,5 @@
+import styled from "styled-components";
+
+export const ResultListWrapper = styled.section`
+  background-color: pink;
+`;

--- a/src/pages/SearchListPage/components/FilteredResultList/FilteredResultList.styled.ts
+++ b/src/pages/SearchListPage/components/FilteredResultList/FilteredResultList.styled.ts
@@ -1,5 +1,4 @@
 import styled from "styled-components";
 
 export const ResultListWrapper = styled.section`
-  background-color: pink;
 `;

--- a/src/pages/SearchListPage/components/FilteredResultList/FilteredResultList.tsx
+++ b/src/pages/SearchListPage/components/FilteredResultList/FilteredResultList.tsx
@@ -1,7 +1,27 @@
+import SearchedShow from "@components/commons/SearchedShow/SearchedShow";
 import * as S from "./FilteredResultList.styled";
 
-const FilteredResultList = () => {
-  return <S.ResultListWrapper>1</S.ResultListWrapper>;
+interface SearchResultPropTypes {
+  id: number;
+  title: string;
+  period: string;
+  location: string;
+  place: string;
+  genre: string;
+  image: string;
+}
+interface ResultListProps {
+  searchResult: SearchResultPropTypes[];
+}
+
+const FilteredResultList = ({ searchResult }: ResultListProps) => {
+  return (
+    <S.ResultListWrapper>
+      {searchResult.map((show) => (
+        <SearchedShow show={show} key={show.id} />
+      ))}
+    </S.ResultListWrapper>
+  );
 };
 
 export default FilteredResultList;

--- a/src/pages/SearchListPage/components/FilteredResultList/FilteredResultList.tsx
+++ b/src/pages/SearchListPage/components/FilteredResultList/FilteredResultList.tsx
@@ -1,0 +1,7 @@
+import * as S from "./FilteredResultList.styled";
+
+const FilteredResultList = () => {
+  return <S.ResultListWrapper>1</S.ResultListWrapper>;
+};
+
+export default FilteredResultList;

--- a/src/pages/SearchListPage/components/Filters/Filters.tsx
+++ b/src/pages/SearchListPage/components/Filters/Filters.tsx
@@ -5,7 +5,7 @@ import { IcDropDown } from "../../../../assets/icons";
 const filters = ["전체(136)", "뮤지컬/연극(116)", "클래식/무용(5)", "전시/행사(15)"];
 const options = ["정확도순", "공연임박순", "판매많은순"];
 const Filters = () => {
-  const [activeFilter, setActiveFilter] = useState<string | null>(null);
+  const [activeFilter, setActiveFilter] = useState<string | null>(filters[0]);
   const [selectedOption, setSelectedOption] = useState<string>(options[0]);
   const [isOpen, setIsOpen] = useState<boolean>(false);
 
@@ -19,7 +19,6 @@ const Filters = () => {
     setSelectedOption(option);
     setIsOpen(false);
   };
-  console.log(isOpen);
   return (
     <>
       <S.FiltersWrapper>

--- a/src/pages/SearchListPage/components/FiltersAndResult/FiltersAndResult.tsx
+++ b/src/pages/SearchListPage/components/FiltersAndResult/FiltersAndResult.tsx
@@ -1,0 +1,37 @@
+import { getSearchResult } from "@apis/SearchApi/getSearchResult";
+import FilteredResultList from "../FilteredResultList/FilteredResultList";
+import Filters from "../Filters/Filters";
+import { useEffect, useState } from "react";
+
+interface SearchResultPropTypes {
+  id: number;
+  title: string;
+  period: string;
+  location: string;
+  place: string;
+  genre: string;
+  image: string;
+}
+
+const FiltersAndResult = () => {
+  const [searchResult, setSearchResult] = useState<SearchResultPropTypes[]>([]);
+  useEffect(() => {
+    const searchWord = localStorage.getItem("searchWord");
+    if (searchWord) {
+      //   setInput(searchWord);
+      fetchSearchResults(searchWord);
+    }
+  }, []);
+  const fetchSearchResults = async (word: string) => {
+    const result = await getSearchResult(word);
+    setSearchResult(result);
+  };
+  return (
+    <>
+      <Filters />
+      <FilteredResultList searchResult={searchResult} />
+    </>
+  );
+};
+
+export default FiltersAndResult;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,8 @@
       "@styles/*": ["src/styles/*"],
       "@constants/*": ["src/constants/*"],
       "@hooks/*": ["src/hooks/*"],
-      "@utils/*": ["src/utils/*"]
+      "@utils/*": ["src/utils/*"],
+      "@apis/*": ["src/apis/*"]
     },
 
     "target": "ES2020",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -14,6 +14,7 @@ export default defineConfig({
       { find: "@constants", replacement: "/src/constants" },
       { find: "@hooks", replacement: "/src/hooks" },
       { find: "@utils", replacement: "/src/utils" },
+      { find: "@apis", replacement: "/src/apis" },
     ],
   },
 });


### PR DESCRIPTION
### ✨ 해당 이슈 번호

resolved #78 

### 🌱 작업 내용

- [x] ~ 검색 시 localStorage에 저장 후 최근 검색어 부분에서 map으로 보여줌
- [x] ~ 전체삭제 구현
- [x] ~ 최근 검색어 없을 때 UI 업데이트


### ✅ PR Point
- 검색어 입력시 localStorage에 `recentWordsList` 라는 key값으로 검색어를 저장 후 최근 검색어 보여주는 컴포넌트에서 이를 보여줬습니다.
- 전체삭제시 localStorage.removeItem('recentWordsList') 로 지워줬습니다. 


### 🌱 Trouble Shooting
- 전체삭제를 구현하면서 `localStorage.removeItem('recentWordsList')` 를 통해 지워줬지만 화면에 update가 되지 않아서 로컬스토리지를 지우는 부분을 함수로 빼서 전체삭제 버튼 클릭시 재호출 해줬지만 그래도 화면에 update가 되지 않았습니다.
그래서 `setWords([]);` 검색어들을 담고 있는 배열 state를 업데이트 해주면서 해결했습니다.


### 👀 스크린샷 (선택)

https://github.com/NOWSOPT-CDSP-WEB-7/YES24-WEB-CLIENT/assets/101498590/0b3a61df-a30d-417c-a760-23ac33c4bd61



### 📚 Reference
