### PR TITLE
[Feat] 좋아요 API PATCH

### DIFF
--- a/src/apis/Detail/patchLike.ts
+++ b/src/apis/Detail/patchLike.ts
@@ -1,0 +1,22 @@
+import axios from "axios";
+
+interface likePropTypes {
+  status: number;
+  success: string;
+  data: {
+    isLike: boolean;
+  }[];
+}
+
+export const patchLike = async (runShowId: number) => {
+  try {
+    const response = await axios.patch<likePropTypes>(`/runshow/like/${runShowId}`, {
+      headers: {
+        memberId: 1,
+      },
+    });
+    return response;
+  } catch (error) {
+    console.error();
+  }
+};

--- a/src/apis/Detail/patchLike.ts
+++ b/src/apis/Detail/patchLike.ts
@@ -1,7 +1,7 @@
 import axios from "axios";
 
 interface likePropTypes {
-  success: string;
+  success: boolean;
   data: {
     isLike: boolean;
   };
@@ -19,6 +19,7 @@ export const patchLike = async (runShowId: number) => {
       }
     );
     return response.data.data.isLike;
+    console.log(response);
   } catch (error) {
     console.error();
   }

--- a/src/apis/Detail/patchLike.ts
+++ b/src/apis/Detail/patchLike.ts
@@ -1,21 +1,24 @@
 import axios from "axios";
 
 interface likePropTypes {
-  status: number;
   success: string;
   data: {
     isLike: boolean;
-  }[];
+  };
 }
 
 export const patchLike = async (runShowId: number) => {
   try {
-    const response = await axios.patch<likePropTypes>(`/runshow/like/${runShowId}`, {
-      headers: {
-        memberId: 1,
-      },
-    });
-    return response;
+    const response = await axios.patch<likePropTypes>(
+      `${import.meta.env.VITE_BASE_URL}runshow/like/${runShowId}`,
+      {},
+      {
+        headers: {
+          memberId: 1,
+        },
+      }
+    );
+    return response.data.data.isLike;
   } catch (error) {
     console.error();
   }

--- a/src/apis/Detail/patchLike.ts
+++ b/src/apis/Detail/patchLike.ts
@@ -19,7 +19,6 @@ export const patchLike = async (runShowId: number) => {
       }
     );
     return response.data.data.isLike;
-    console.log(response);
   } catch (error) {
     console.error();
   }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -8,11 +8,11 @@ import GlobalStyles from "./styles/GlobalStyle.ts";
 import theme from "./styles/theme.ts";
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
-  <React.StrictMode>
+  <>
     <GlobalStyles />
     <ThemeProvider theme={theme}>
       <Router />
       <App />
     </ThemeProvider>
-  </React.StrictMode>
+  </>
 );

--- a/src/pages/Detail/components/ShowInfo/ShowInfo.tsx
+++ b/src/pages/Detail/components/ShowInfo/ShowInfo.tsx
@@ -11,12 +11,16 @@ const ShowInfo = () => {
   const { runShowId } = useParams();
   const [showData, setShowData] = useState<ShowDetailPropTypes>();
   const [isLike, setIsLike] = useState(false);
+  const [isLikeCount, setIsLikeCount] = useState(0);
 
   useEffect(() => {
     const fetchData = async () => {
       try {
         const data = await fetchShowDetail(Number(runShowId));
         setShowData(data);
+        setIsLikeCount(data?.likeCount ?? 0);
+        const initialLike = await patchLike(Number(runShowId));
+        setIsLike(initialLike ?? false);
       } catch (error) {
         console.error(error);
       }
@@ -24,17 +28,12 @@ const ShowInfo = () => {
     fetchData();
   }, [runShowId]);
 
+  // 좋아요 버튼 눌렀을 때 동작하는 핸들러
   const handleLikeClick = async () => {
     try {
-      const likeStatus = await patchLike(Number(runShowId));
-      setIsLike(likeStatus ?? false);
-      setShowData((prevData) => {
-        if (!prevData) {
-          return prevData;
-        }
-        const updatedLikeCount = likeStatus ? prevData.likeCount + 1 : prevData.likeCount - 1;
-        return { ...prevData, likeCount: updatedLikeCount };
-      });
+      const likeStatus = !isLike;
+      setIsLike(likeStatus);
+      setIsLikeCount((prev) => (likeStatus ? prev + 1 : prev - 1));
     } catch (error) {
       console.error(error);
     }
@@ -66,7 +65,7 @@ const ShowInfo = () => {
             <S.BtnLayout>
               <S.HeartBtnBox onClick={handleLikeClick}>
                 {isLike ? <IcHeartFill /> : <IcHeartEmpty />}
-                <S.HeartNum>{showData?.likeCount}</S.HeartNum>
+                <S.HeartNum>{isLikeCount}</S.HeartNum>
               </S.HeartBtnBox>
               <IcBtnShare />
             </S.BtnLayout>

--- a/src/pages/Detail/components/ShowInfo/ShowInfo.tsx
+++ b/src/pages/Detail/components/ShowInfo/ShowInfo.tsx
@@ -5,10 +5,12 @@ import { categories } from "../../../../constants/showDetailCategory";
 
 import * as S from "./ShowInfo.styled";
 import { ShowDetailPropTypes, fetchShowDetail } from "../../../../apis/Detail/fetchShowDetail";
+import { patchLike } from "src/apis/Detail/patchLike";
 
 const ShowInfo = () => {
   const { runShowId } = useParams();
   const [showData, setShowData] = useState<ShowDetailPropTypes>();
+  const [isLike, setIslLike] = useState<boolean>(false);
 
   useEffect(() => {
     const fetchData = async () => {
@@ -25,6 +27,10 @@ const ShowInfo = () => {
     };
     fetchData();
   }, [runShowId]);
+
+  const fetchLikeData = () => {
+    patchLike();
+  };
 
   return (
     <>

--- a/src/pages/Detail/components/ShowInfo/ShowInfo.tsx
+++ b/src/pages/Detail/components/ShowInfo/ShowInfo.tsx
@@ -1,35 +1,43 @@
 import { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
-import { IcBtnShare, IcHeartFill } from "../../../../assets/icons";
+import { IcBtnShare, IcHeartEmpty, IcHeartFill } from "../../../../assets/icons";
 import { categories } from "../../../../constants/showDetailCategory";
 
 import * as S from "./ShowInfo.styled";
 import { ShowDetailPropTypes, fetchShowDetail } from "../../../../apis/Detail/fetchShowDetail";
-import { patchLike } from "src/apis/Detail/patchLike";
+import { patchLike } from "../../../../apis/Detail/patchLike";
 
 const ShowInfo = () => {
   const { runShowId } = useParams();
   const [showData, setShowData] = useState<ShowDetailPropTypes>();
-  const [isLike, setIslLike] = useState<boolean>(false);
+  const [isLike, setIsLike] = useState(false);
 
   useEffect(() => {
     const fetchData = async () => {
-      if (runShowId) {
-        try {
-          const data = await fetchShowDetail(Number(runShowId));
-          if (data) {
-            setShowData(data);
-          }
-        } catch (error) {
-          console.error(error);
-        }
+      try {
+        const data = await fetchShowDetail(Number(runShowId));
+        setShowData(data);
+      } catch (error) {
+        console.error(error);
       }
     };
     fetchData();
   }, [runShowId]);
 
-  const fetchLikeData = () => {
-    patchLike();
+  const handleLikeClick = async () => {
+    try {
+      const likeStatus = await patchLike(Number(runShowId));
+      setIsLike(likeStatus ?? false);
+      setShowData((prevData) => {
+        if (!prevData) {
+          return prevData;
+        }
+        const updatedLikeCount = likeStatus ? prevData.likeCount + 1 : prevData.likeCount - 1;
+        return { ...prevData, likeCount: updatedLikeCount };
+      });
+    } catch (error) {
+      console.error(error);
+    }
   };
 
   return (
@@ -56,8 +64,8 @@ const ShowInfo = () => {
               </S.InfoBox>
             </S.ShowInfoContainer>
             <S.BtnLayout>
-              <S.HeartBtnBox>
-                <IcHeartFill />
+              <S.HeartBtnBox onClick={handleLikeClick}>
+                {isLike ? <IcHeartFill /> : <IcHeartEmpty />}
                 <S.HeartNum>{showData?.likeCount}</S.HeartNum>
               </S.HeartBtnBox>
               <IcBtnShare />


### PR DESCRIPTION
### ✨ 해당 이슈 번호

resolved #68 

### 🌱 작업 내용

- [x] 좋아요 API PATCH


### ✅ PR Point
```tsx
  useEffect(() => {
    const fetchData = async () => {
      try {
        const data = await fetchShowDetail(Number(runShowId));
        setShowData(data);
        setIsLikeCount(data?.likeCount ?? 0);
        const initialLike = await patchLike(Number(runShowId));
        setIsLike(initialLike ?? false);
      } catch (error) {
        console.error(error);
      }
    };
    fetchData();
  }, [runShowId]);
```
- 공연 데이터 GET해오는 useEffect에서 PATCH해오는 함수도 호출해줬습니다


```tsx
  const [isLike, setIsLike] = useState(false);
  const [isLikeCount, setIsLikeCount] = useState(0);
```
- 좋아요 여부(true, false)를 setIsLike 상태에 저장하고, 좋아요 개수 업데이트를 반영하기 위해 GET으로 받아온 좋아요 개수도 상태에 저장해줬어요


### 🌱 Trouble Shooting
### 🧩 ~는 undefined 일 수 있습니다 에러 
- useEffect에서 `setIsLike(initialLike ?? false);`의 ?? 연산자는 `널 병합 연산자`로, initialLike의 값이 null이거나 undefined인 경우 오른쪽 피연산자의 값을 저장해주는 연산자입니다. 해당 연산자를 사용해서 initialLike의 값이 undefined일 수도 있다는 에러를 해결해줬어요

### 🧩 API가 두 번씩 호출되는 에러
- React18부터 React.Strict을 적용하는 경우 useEffect 훅이 두 번씩 호출된다고 합니다. 
- 따라서 main.tsx에서 최상단으로 감싸준 React.Strict 태그를 없애줌으로써 해결할 수 있었어요


### 👀 스크린샷 (선택)

https://github.com/NOWSOPT-CDSP-WEB-7/YES24-WEB-CLIENT/assets/96781926/866a9b85-fdc4-498d-80d3-a9021b2f2cdc



### 📚 Reference

- [구현에 참고한 링크](https://github.com/facebook/react/issues/24502) 
