### PR TITLE
[Feat] /search/list 페이지에서 재검색 안되는 에러 수정

### DIFF
--- a/src/apis/SearchApi/getSearchResult.ts
+++ b/src/apis/SearchApi/getSearchResult.ts
@@ -3,8 +3,7 @@ import axios from "axios";
 export const getSearchResult = async (input: string) => {
   try {
     const response = await axios.get(
-      // `${import.meta.env.VITE_BASE_URL}runshow/search?query=${input}`,
-      "/data/search-result.json",
+      `${import.meta.env.VITE_BASE_URL}runshow/search?query=${input}`,
       {
         headers: {
           "Content-Type": "application/json",

--- a/src/components/commons/DeleteAllBtn/DeleteAllBtn.tsx
+++ b/src/components/commons/DeleteAllBtn/DeleteAllBtn.tsx
@@ -1,7 +1,12 @@
 import * as S from "./DeleteAllBtn.styled";
-const DeleteAllBtn = () => {
+
+interface DeleteAllPropTypes {
+  onClick: () => void;
+}
+
+const DeleteAllBtn = ({ onClick }: DeleteAllPropTypes) => {
   return (
-    <S.BtnContainer>
+    <S.BtnContainer onClick={onClick}>
       <S.DeleteBtn>전체삭제</S.DeleteBtn>
     </S.BtnContainer>
   );

--- a/src/components/commons/SearchedShow/SearchedShow.tsx
+++ b/src/components/commons/SearchedShow/SearchedShow.tsx
@@ -1,5 +1,4 @@
 import * as S from "./SearchedShow.styled";
-import showImg from "../../../assets/images/show.png";
 
 interface SearchResultPropTypes {
   id: number;
@@ -16,7 +15,7 @@ const SearchedShow = ({ show }: { show: SearchResultPropTypes }) => {
   return (
     <>
       <S.ShowWrapper>
-        <S.ShowImg src={showImg} />
+        <S.ShowImg src={image} />
         <S.ShowRightSec>
           <S.ShowStatusBtns>
             <S.StatusBtn color={"Text_01"} backcolor={"UI_02"}>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -8,11 +8,11 @@ import GlobalStyles from "./styles/GlobalStyle.ts";
 import theme from "./styles/theme.ts";
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
-  <React.StrictMode>
+  <>
     <GlobalStyles />
     <ThemeProvider theme={theme}>
       <Router />
       <App />
     </ThemeProvider>
-  </React.StrictMode>
+  </>
 );

--- a/src/pages/Search/components/RecentWord/RecentWord.tsx
+++ b/src/pages/Search/components/RecentWord/RecentWord.tsx
@@ -3,13 +3,17 @@ import { IcCancel } from "../../../../assets/icons";
 
 interface WordPropTypes {
   word: string;
+  onDelete: (word: string) => void;
 }
 
-const RecentWord = ({ word }: WordPropTypes) => {
+const RecentWord = ({ word, onDelete }: WordPropTypes) => {
+  const handleWordDelete = () => {
+    onDelete(word);
+  };
   return (
     <S.WordWrapper>
       <S.Word>{word}</S.Word>
-      <S.CancelBtn>
+      <S.CancelBtn onClick={handleWordDelete}>
         <IcCancel />
       </S.CancelBtn>
     </S.WordWrapper>

--- a/src/pages/Search/components/RecentWords/RecentWords.styled.ts
+++ b/src/pages/Search/components/RecentWords/RecentWords.styled.ts
@@ -3,5 +3,12 @@ import styled from "styled-components";
 export const Wrapper = styled.section`
   width: 100%;
   height: auto;
+`;
+export const NoRecentWords = styled.span`
+  margin-top: 4.4rem;
 
+  color: ${({ theme }) => theme.colors.Text_02};
+  text-align: center;
+
+  ${({ theme }) => theme.fonts.sub_14pt};
 `;

--- a/src/pages/Search/components/RecentWords/RecentWords.tsx
+++ b/src/pages/Search/components/RecentWords/RecentWords.tsx
@@ -1,12 +1,23 @@
 import * as S from "./RecentWords.styled";
 import RecentWord from "../RecentWord/RecentWord";
 import DeleteAllBtn from "@components/commons/DeleteAllBtn/DeleteAllBtn";
+import { useEffect, useState } from "react";
 
 const RecentWords = () => {
-  const words: string[] = ["레베카", "울산", "서울"];
+  const [words, setWords] = useState([]);
+  useEffect(() => {
+    const recentWordsList = localStorage.getItem("recentWordsList");
+    if (recentWordsList) {
+      const parsedWords = JSON.parse(recentWordsList);
+      setWords(parsedWords);
+    }
+  }, []);
   if (words.length === 0) {
     return <div>최근 검색어가 없습니다.</div>;
   }
+  const handleDeleteAll = () => {
+    localStorage.removeItem("recentWordsList");
+  };
   return (
     <>
       <S.Wrapper>
@@ -18,7 +29,7 @@ const RecentWords = () => {
           </div>
         )}
       </S.Wrapper>
-      <DeleteAllBtn />
+      <DeleteAllBtn onClick={handleDeleteAll} />
     </>
   );
 };

--- a/src/pages/Search/components/RecentWords/RecentWords.tsx
+++ b/src/pages/Search/components/RecentWords/RecentWords.tsx
@@ -16,7 +16,7 @@ const RecentWords = () => {
     }
   };
   if (words.length === 0) {
-    return <div>최근 검색어가 없습니다.</div>;
+    return <S.NoRecentWords>최근 검색어가 없습니다</S.NoRecentWords>;
   }
   const handleDeleteAll = () => {
     localStorage.removeItem("recentWordsList");

--- a/src/pages/Search/components/RecentWords/RecentWords.tsx
+++ b/src/pages/Search/components/RecentWords/RecentWords.tsx
@@ -22,13 +22,18 @@ const RecentWords = () => {
     localStorage.removeItem("recentWordsList");
     setWords([]);
   };
+  const handleDeleteWord = (word: string) => {
+    const updatedWords = words.filter((w) => w !== word);
+    localStorage.setItem("recentWordsList", JSON.stringify(updatedWords));
+    setWords(updatedWords);
+  };
   return (
     <>
       <S.Wrapper>
         {words && (
           <div>
             {words.map((word, i) => {
-              return <RecentWord key={i} word={word} />;
+              return <RecentWord key={i} word={word} onDelete={handleDeleteWord} />;
             })}
           </div>
         )}

--- a/src/pages/Search/components/RecentWords/RecentWords.tsx
+++ b/src/pages/Search/components/RecentWords/RecentWords.tsx
@@ -6,17 +6,21 @@ import { useEffect, useState } from "react";
 const RecentWords = () => {
   const [words, setWords] = useState([]);
   useEffect(() => {
+    getRecentWordsList();
+  }, []);
+  const getRecentWordsList = () => {
     const recentWordsList = localStorage.getItem("recentWordsList");
     if (recentWordsList) {
       const parsedWords = JSON.parse(recentWordsList);
       setWords(parsedWords);
     }
-  }, []);
+  };
   if (words.length === 0) {
     return <div>최근 검색어가 없습니다.</div>;
   }
   const handleDeleteAll = () => {
     localStorage.removeItem("recentWordsList");
+    setWords([]);
   };
   return (
     <>

--- a/src/pages/Search/components/SearchBar/SearchBar.tsx
+++ b/src/pages/Search/components/SearchBar/SearchBar.tsx
@@ -42,6 +42,8 @@ const SearchBar = () => {
 
     if (location.pathname === "/search") {
       navigate("list");
+    } else {
+      window.location.reload();
     }
   };
   const handleKeyPress = (e: { key: string }) => {

--- a/src/pages/Search/components/SearchBar/SearchBar.tsx
+++ b/src/pages/Search/components/SearchBar/SearchBar.tsx
@@ -3,21 +3,26 @@ import { IcSearch, IcCancel } from "../../../../assets/icons";
 import useChangeInput from "../../../../hooks/useChangeInput.ts";
 import SearchList from "../SearchList/SearchList.tsx";
 import { useLocation, useNavigate } from "react-router-dom";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 
 const SearchBar = () => {
   const { input, setInput, handleInputChange } = useChangeInput();
   const navigate = useNavigate();
   const location = useLocation();
+  const [recentWordsList, setRecentWordsList] = useState<string[]>([]);
 
   useEffect(() => {
     const savedInputWord = localStorage.getItem("searchWord");
+    const savedRecentWordsList = localStorage.getItem("recentWordsList");
     if (savedInputWord) {
       setInput(savedInputWord);
     }
     if (location.pathname === "/search") {
       localStorage.removeItem("searchWord");
       setInput("");
+    }
+    if (savedRecentWordsList) {
+      setRecentWordsList(JSON.parse(savedRecentWordsList));
     }
   }, [setInput, location.pathname]);
 
@@ -27,6 +32,9 @@ const SearchBar = () => {
     }
 
     localStorage.setItem("searchWord", input);
+    const updatedRecentWordsList = [input, ...recentWordsList.filter((word) => word !== input)];
+    setRecentWordsList(updatedRecentWordsList);
+    localStorage.setItem("recentWordsList", JSON.stringify(updatedRecentWordsList));
 
     navigate("list");
   };

--- a/src/pages/Search/components/SearchBar/SearchBar.tsx
+++ b/src/pages/Search/components/SearchBar/SearchBar.tsx
@@ -26,17 +26,23 @@ const SearchBar = () => {
     }
   }, [setInput, location.pathname]);
 
+  const updateRecentWordsList = (newWord: string) => {
+    localStorage.setItem("searchWord", newWord);
+    const updatedRecentWordsList = [newWord, ...recentWordsList.filter((word) => word !== newWord)];
+    setRecentWordsList(updatedRecentWordsList);
+    localStorage.setItem("recentWordsList", JSON.stringify(updatedRecentWordsList));
+  };
+
   const handleSearchClick = async () => {
     if (input.trim().length === 0) {
       return;
     }
 
-    localStorage.setItem("searchWord", input);
-    const updatedRecentWordsList = [input, ...recentWordsList.filter((word) => word !== input)];
-    setRecentWordsList(updatedRecentWordsList);
-    localStorage.setItem("recentWordsList", JSON.stringify(updatedRecentWordsList));
+    updateRecentWordsList(input);
 
-    navigate("list");
+    if (location.pathname === "/search") {
+      navigate("list");
+    }
   };
   const handleKeyPress = (e: { key: string }) => {
     if (e.key === "Enter") {

--- a/src/pages/SearchListPage/components/Filters/Filters.tsx
+++ b/src/pages/SearchListPage/components/Filters/Filters.tsx
@@ -1,13 +1,54 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import * as S from "./Filters.styled";
 import { IcDropDown } from "../../../../assets/icons";
 
-const filters = ["전체(136)", "뮤지컬/연극(116)", "클래식/무용(5)", "전시/행사(15)"];
 const options = ["정확도순", "공연임박순", "판매많은순"];
-const Filters = () => {
-  const [activeFilter, setActiveFilter] = useState<string | null>(filters[0]);
+
+// 고정된 필터 이름 배열
+const fixedFilters = [
+  { name: "전체" },
+  { name: "뮤지컬/연극" },
+  { name: "클래식/무용" },
+  { name: "전시/행사" },
+];
+
+// 각 장르가 어떤 필터에 속하는지 정의
+const genreToFilter = {
+  musical: ["뮤지컬/연극"],
+  theater: ["뮤지컬/연극"],
+  classic: ["클래식/무용"],
+  dancing: ["클래식/무용"],
+  exhibition: ["전시/행사"],
+  event: ["전시/행사"],
+};
+
+const Filters = ({ genres }) => {
+  const genreCounts = genres.reduce((acc, genre) => {
+    const filterNames = genreToFilter[genre];
+    if (filterNames) {
+      filterNames.forEach((filterName) => {
+        acc[filterName] = (acc[filterName] || 0) + 1;
+      });
+    }
+    return acc;
+  }, {});
+
+  const totalCount = genres.length;
+
+  const filters = fixedFilters.map((filter) => {
+    const count = filter.name === "전체" ? totalCount : genreCounts[filter.name] || 0;
+    return `${filter.name}(${count})`;
+  });
+
+  const [activeFilter, setActiveFilter] = useState<string | null>(null);
   const [selectedOption, setSelectedOption] = useState<string>(options[0]);
   const [isOpen, setIsOpen] = useState<boolean>(false);
+
+  useEffect(() => {
+    if (filters.length > 0) {
+      setActiveFilter(filters[0]);
+    }
+  }, [filters]);
 
   const handleFilterClick = (filter: string) => {
     setActiveFilter(filter);
@@ -19,6 +60,7 @@ const Filters = () => {
     setSelectedOption(option);
     setIsOpen(false);
   };
+
   return (
     <>
       <S.FiltersWrapper>
@@ -32,7 +74,7 @@ const Filters = () => {
         })}
       </S.FiltersWrapper>
       <S.FilterResultAndSort>
-        <S.FilterResult>총 116개의 검색 결과가 나왔습니다.</S.FilterResult>
+        <S.FilterResult>총 {totalCount}개의 검색 결과가 나왔습니다.</S.FilterResult>
         <S.SortBox>
           <S.SelectSortWrapper>
             <S.SelectedSort>{selectedOption}</S.SelectedSort>

--- a/src/pages/SearchListPage/components/FiltersAndResult/FiltersAndResult.tsx
+++ b/src/pages/SearchListPage/components/FiltersAndResult/FiltersAndResult.tsx
@@ -16,13 +16,20 @@ interface SearchResultPropTypes {
 const FiltersAndResult = () => {
   const [searchResult, setSearchResult] = useState<SearchResultPropTypes[]>([]);
   const [genres, setGenres] = useState<string[]>([]);
+  const [searchWord, setSearchWord] = useState<string | null>(null);
 
   useEffect(() => {
-    const searchWord = localStorage.getItem("searchWord");
+    const storedSearchWord = localStorage.getItem("searchWord");
+    if (storedSearchWord) {
+      setSearchWord(storedSearchWord);
+    }
+  }, []);
+
+  useEffect(() => {
     if (searchWord) {
       fetchSearchResults(searchWord);
     }
-  }, []);
+  }, [searchWord]);
   const fetchSearchResults = async (word: string) => {
     const result = await getSearchResult(word);
     setSearchResult(result);

--- a/src/pages/SearchListPage/components/FiltersAndResult/FiltersAndResult.tsx
+++ b/src/pages/SearchListPage/components/FiltersAndResult/FiltersAndResult.tsx
@@ -15,6 +15,8 @@ interface SearchResultPropTypes {
 
 const FiltersAndResult = () => {
   const [searchResult, setSearchResult] = useState<SearchResultPropTypes[]>([]);
+  const [genres, setGenres] = useState<string[]>([]);
+
   useEffect(() => {
     const searchWord = localStorage.getItem("searchWord");
     if (searchWord) {
@@ -24,10 +26,13 @@ const FiltersAndResult = () => {
   const fetchSearchResults = async (word: string) => {
     const result = await getSearchResult(word);
     setSearchResult(result);
+
+    const extractedGenres = result.map((item) => item.genre);
+    setGenres(extractedGenres);
   };
   return (
     <>
-      <Filters />
+      <Filters genres={genres} />
       <FilteredResultList searchResult={searchResult} />
     </>
   );


### PR DESCRIPTION
### ✨ 해당 이슈 번호

resolved #83 

### 🌱 작업 내용

- [x] /search/list 페이지에서 재검색 안되는 에러 수정했습니다.


### ✅ PR Point
```js
if (location.pathname === "/search") {
      navigate("list");
    } else {
      window.location.reload();
    }
```
현재 url에 따라 라우팅을 달리 해줬습니다.


### 🌱 Trouble Shooting
- 검색어를 SearchBar 컴포넌트와 그 아래 FiltersAndResult 컴포넌트에서 공유해야하는데 이걸 하기 위해 굳이 부모 컴포넌트에 state를 또 생성해서 주고 받고 하는 과정이 불필요하다 판단했고, 원래 정석으로 검색어를 구현할때도 query parameter에 값이 변하면서 url이 바뀌기 때문에
저도 비슷한 방식으로 그냥 window.location.reload() 방식을 선택하여 간단하게 UI를 업데이트 해주었습니다.


### 👀 스크린샷 (선택)


### 📚 Reference

