### PR TITLE
[Feat] 최근 검색 공연 추가

### DIFF
--- a/src/components/commons/DeleteAllBtn/DeleteAllBtn.tsx
+++ b/src/components/commons/DeleteAllBtn/DeleteAllBtn.tsx
@@ -1,7 +1,11 @@
 import * as S from "./DeleteAllBtn.styled";
-const DeleteAllBtn = () => {
+
+interface DeleteAllPropTypes {
+  handleDelete: () => void;
+}
+const DeleteAllBtn = ({ handleDelete }: DeleteAllPropTypes) => {
   return (
-    <S.BtnContainer>
+    <S.BtnContainer onClick={handleDelete}>
       <S.DeleteBtn>전체삭제</S.DeleteBtn>
     </S.BtnContainer>
   );

--- a/src/components/commons/SearchedShow/SearchedShow.tsx
+++ b/src/components/commons/SearchedShow/SearchedShow.tsx
@@ -17,6 +17,14 @@ const SearchedShow = ({ show }: { show: SearchResultPropTypes }) => {
   const navigate = useNavigate();
 
   const handleShowClick = () => {
+    const recentShows = localStorage.getItem("recentShows");
+    let recentShowsList = recentShows ? JSON.parse(recentShows) : [];
+
+    recentShowsList = recentShowsList.filter((item: SearchResultPropTypes) => item.id !== id);
+
+    recentShowsList.unshift(show);
+
+    localStorage.setItem("recentShows", JSON.stringify(recentShowsList));
     navigate(`/detail/${id}`);
   };
   return (

--- a/src/pages/Search/components/RecentShows/RecentShows.styled.ts
+++ b/src/pages/Search/components/RecentShows/RecentShows.styled.ts
@@ -5,3 +5,10 @@ export const Wrapper = styled.section`
   flex-direction: column;
   align-items: flex-end;
 `;
+export const NoRecentShows = styled.span`
+  margin-top: 4.4rem;
+
+  color: ${({ theme }) => theme.colors.Text_02};
+  text-align: center;
+  ${({ theme }) => theme.fonts.sub_14pt};
+`;

--- a/src/pages/Search/components/RecentShows/RecentShows.tsx
+++ b/src/pages/Search/components/RecentShows/RecentShows.tsx
@@ -1,10 +1,36 @@
 import DeleteAllBtn from "@components/commons/DeleteAllBtn/DeleteAllBtn";
 import SearchedShow from "../../../../components/commons/SearchedShow/SearchedShow";
+import { useEffect, useState } from "react";
+
+interface SearchResultPropTypes {
+  id: number;
+  title: string;
+  period: string;
+  location: string;
+  place: string;
+  genre: string;
+  image: string;
+}
 
 const RecentShows = () => {
+  const [recentShows, setRecentShows] = useState<SearchResultPropTypes[]>([]);
+  useEffect(() => {
+    const recentShowsArr = localStorage.getItem("recentShows");
+    if (recentShowsArr) {
+      setRecentShows(JSON.parse(recentShowsArr));
+    } else {
+      localStorage.setItem("recentShows", JSON.stringify([]));
+    }
+  }, []);
+  if (recentShows.length === 0) {
+    return <div>최근 검색 공연이 없습니다</div>;
+  }
+  console.log(recentShows);
   return (
     <>
-      <SearchedShow />
+      {recentShows.length !== 0 &&
+        recentShows.map((recentShow) => <SearchedShow show={recentShow} key={recentShow.id} />)}
+
       <DeleteAllBtn />
     </>
   );

--- a/src/pages/Search/components/RecentShows/RecentShows.tsx
+++ b/src/pages/Search/components/RecentShows/RecentShows.tsx
@@ -22,6 +22,11 @@ const RecentShows = () => {
       localStorage.setItem("recentShows", JSON.stringify([]));
     }
   }, []);
+
+  const handleDeleteAll = () => {
+    localStorage.removeItem("recentShows");
+    setRecentShows([]);
+  };
   if (recentShows.length === 0) {
     return <div>최근 검색 공연이 없습니다</div>;
   }
@@ -31,7 +36,7 @@ const RecentShows = () => {
       {recentShows.length !== 0 &&
         recentShows.map((recentShow) => <SearchedShow show={recentShow} key={recentShow.id} />)}
 
-      <DeleteAllBtn />
+      <DeleteAllBtn handleDelete={handleDeleteAll} />
     </>
   );
 };

--- a/src/pages/Search/components/RecentShows/RecentShows.tsx
+++ b/src/pages/Search/components/RecentShows/RecentShows.tsx
@@ -1,5 +1,6 @@
 import DeleteAllBtn from "@components/commons/DeleteAllBtn/DeleteAllBtn";
 import SearchedShow from "../../../../components/commons/SearchedShow/SearchedShow";
+import * as S from "./RecentShows.styled";
 import { useEffect, useState } from "react";
 
 interface SearchResultPropTypes {
@@ -28,7 +29,7 @@ const RecentShows = () => {
     setRecentShows([]);
   };
   if (recentShows.length === 0) {
-    return <div>최근 검색 공연이 없습니다</div>;
+    return <S.NoRecentShows>최근 검색 공연이 없습니다</S.NoRecentShows>;
   }
   console.log(recentShows);
   return (


### PR DESCRIPTION
### ✨ 해당 이슈 번호

resolved #87 

### 🌱 작업 내용

- [x] /search/list 페이지에서 특정 공연을 클릭했을 때 라우팅과 동시에 localStorage에 해당 쇼 정보를 저장합니다.
- [x] 저장된 배열을 최근 검색 공연 탭에서 불러와 map으로 반복해줍니다.
- [x] 전체 삭제 기능을 구현했습니다.
- [x] 최근 검색 공연이 없을 시 스타일링 했습니다.


### ✅ PR Point
- 최근 검색어와 똑같은 로직이라 특별한거 없습니당.


### 🌱 Trouble Shooting
- 개발 중 겪은 트러블 정리!


### 👀 스크린샷 (선택)


### 📚 Reference
