### PR TITLE
[Fix] 실시간 검색어에 일치하는 결과물 있는지 확인하는 부분 수정

### DIFF
--- a/src/components/commons/SearchedShow/SearchedShow.tsx
+++ b/src/components/commons/SearchedShow/SearchedShow.tsx
@@ -1,5 +1,4 @@
 import * as S from "./SearchedShow.styled";
-import showImg from "../../../assets/images/show.png";
 import { useNavigate } from "react-router-dom";
 
 interface SearchResultPropTypes {

--- a/src/hooks/useGetSearchResult.ts
+++ b/src/hooks/useGetSearchResult.ts
@@ -11,16 +11,19 @@ interface searchResultPropTypes {
   genre: string;
 }
 
-const useGetSearchResult = () => {
+const useGetSearchResult = (input: string) => {
   const [searchResult, setSearchResult] = useState<searchResultPropTypes[]>([]);
 
   const getSearchResult = async () => {
     try {
-      const response = await axios.get("/data/search-result.json", {
-        headers: {
-          "Content-Type": "application/json",
-        },
-      });
+      const response = await axios.get(
+        `${import.meta.env.VITE_BASE_URL}runshow/search?query=${input}`,
+        {
+          headers: {
+            "Content-Type": "application/json",
+          },
+        }
+      );
       setSearchResult(response.data.data);
     } catch (error) {
       console.log(error);
@@ -29,7 +32,7 @@ const useGetSearchResult = () => {
 
   useEffect(() => {
     getSearchResult();
-  }, []);
+  }, [input]);
 
   return { searchResult, getSearchResult };
 };

--- a/src/pages/Search/components/SearchList/SearchList.tsx
+++ b/src/pages/Search/components/SearchList/SearchList.tsx
@@ -1,13 +1,12 @@
 import useGetSearchResult from "../../../../hooks/useGetSearchResult.ts";
 import * as S from "./SearchList.styled.ts";
-import showImg from "../../../../assets/images/show.png";
 
 interface InputPropTypes {
   input: string;
 }
 
 const SearchList = ({ input }: InputPropTypes) => {
-  const { searchResult } = useGetSearchResult();
+  const { searchResult } = useGetSearchResult(input);
 
   const highlightText = (text: string, searchInput: string) => {
     const regex = new RegExp(`(${searchInput})`, "gi");
@@ -36,7 +35,7 @@ const SearchList = ({ input }: InputPropTypes) => {
     <S.SearchListWrapper>
       {filteredResult.map((item) => (
         <S.SearchLi key={item.id}>
-          <S.LiImg src={showImg} alt="showimg" />
+          <S.LiImg src={item.image} alt="showimg" />
           <S.LiTextBox>
             {highlightLocation(item.location, input)}
             <S.LiTitle>{highlightText(item.title, input)}</S.LiTitle>

--- a/src/pages/SearchListPage/components/Filters/Filters.styled.ts
+++ b/src/pages/SearchListPage/components/Filters/Filters.styled.ts
@@ -57,7 +57,9 @@ export const SelectedSort = styled.span`
   padding: 0.5rem;
 
   color: ${({ theme }) => theme.colors.Text_01};
+
   ${({ theme }) => theme.fonts.sub_12pt};
+  cursor: pointer;
 `;
 export const DropdownBtn = styled.button`
   display: flex;
@@ -87,6 +89,7 @@ export const SortItem = styled.li`
   white-space: nowrap;
 
   ${({ theme }) => theme.fonts.dropdown_11pt};
+  cursor: pointer;
 
   &:hover {
     color: ${({ theme }) => theme.colors.Secondary_orange};

--- a/src/pages/SearchListPage/components/Filters/Filters.tsx
+++ b/src/pages/SearchListPage/components/Filters/Filters.tsx
@@ -4,33 +4,44 @@ import { IcDropDown } from "../../../../assets/icons";
 
 const options = ["정확도순", "공연임박순", "판매많은순"];
 
+interface FixedFilterPropTypes {
+  name: string;
+}
+interface GenreToFilterPropTypes {
+  [key: string]: string[];
+}
+interface FiltersPropTypes {
+  genres: string[];
+}
 // 고정된 필터 이름 배열
-const fixedFilters = [
+const fixedFilters: FixedFilterPropTypes[] = [
   { name: "전체" },
   { name: "뮤지컬/연극" },
   { name: "클래식/무용" },
   { name: "전시/행사" },
+  { name: "콘서트" },
 ];
 
 // 각 장르가 어떤 필터에 속하는지 정의
-const genreToFilter = {
+const genreToFilter: GenreToFilterPropTypes = {
   musical: ["뮤지컬/연극"],
   theater: ["뮤지컬/연극"],
   classic: ["클래식/무용"],
   dancing: ["클래식/무용"],
   exhibition: ["전시/행사"],
   event: ["전시/행사"],
+  concert: ["콘서트"],
 };
 
-const Filters = ({ genres }) => {
-  const genreCounts = genres.reduce((acc, genre) => {
+const Filters = ({ genres }: FiltersPropTypes) => {
+  const genreCounts = genres.reduce<{ [key: string]: number }>((genreCount, genre) => {
     const filterNames = genreToFilter[genre];
     if (filterNames) {
       filterNames.forEach((filterName) => {
-        acc[filterName] = (acc[filterName] || 0) + 1;
+        genreCount[filterName] = (genreCount[filterName] || 0) + 1;
       });
     }
-    return acc;
+    return genreCount;
   }, {});
 
   const totalCount = genres.length;
@@ -40,15 +51,21 @@ const Filters = ({ genres }) => {
     return `${filter.name}(${count})`;
   });
 
-  const [activeFilter, setActiveFilter] = useState<string | null>(null);
+  const [activeFilter, setActiveFilter] = useState<string>(filters[0]);
   const [selectedOption, setSelectedOption] = useState<string>(options[0]);
   const [isOpen, setIsOpen] = useState<boolean>(false);
 
-  useEffect(() => {
-    if (filters.length > 0) {
-      setActiveFilter(filters[0]);
-    }
-  }, [filters]);
+  // useEffect(() => {
+  //   console.log(filters.length);
+  //   if (filters.length > 0) {
+  //     setActiveFilter(filters[0]);
+  //   }
+  // }, []);
+  // useEffect(() => {
+  //   if (filters.length > 0 && !activeFilter) {
+  //     setActiveFilter(filters[0]);
+  //   }
+  // }, [filters, activeFilter]);
 
   const handleFilterClick = (filter: string) => {
     setActiveFilter(filter);
@@ -65,7 +82,7 @@ const Filters = ({ genres }) => {
     <>
       <S.FiltersWrapper>
         {filters.map((filter, i) => {
-          const isActive = activeFilter === filter;
+          const isActive = activeFilter.slice(0, 2) === filter.slice(0, 2);
           return (
             <S.FilterBtn key={i} $isActive={isActive} onClick={() => handleFilterClick(filter)}>
               {filter}
@@ -76,9 +93,9 @@ const Filters = ({ genres }) => {
       <S.FilterResultAndSort>
         <S.FilterResult>총 {totalCount}개의 검색 결과가 나왔습니다.</S.FilterResult>
         <S.SortBox>
-          <S.SelectSortWrapper>
+          <S.SelectSortWrapper onClick={toggleDropdown}>
             <S.SelectedSort>{selectedOption}</S.SelectedSort>
-            <S.DropdownBtn onClick={toggleDropdown}>
+            <S.DropdownBtn>
               <IcDropDown />
             </S.DropdownBtn>
           </S.SelectSortWrapper>

--- a/src/pages/SearchListPage/components/Filters/Filters.tsx
+++ b/src/pages/SearchListPage/components/Filters/Filters.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import * as S from "./Filters.styled";
 import { IcDropDown } from "../../../../assets/icons";
 
@@ -12,6 +12,7 @@ interface GenreToFilterPropTypes {
 }
 interface FiltersPropTypes {
   genres: string[];
+  handleGenreClick: (clickedGenres: string[]) => void;
 }
 // 고정된 필터 이름 배열
 const fixedFilters: FixedFilterPropTypes[] = [
@@ -28,12 +29,22 @@ const genreToFilter: GenreToFilterPropTypes = {
   theater: ["뮤지컬/연극"],
   classic: ["클래식/무용"],
   dancing: ["클래식/무용"],
-  exhibition: ["전시/행사"],
+  exhibit: ["전시/행사"],
   event: ["전시/행사"],
   concert: ["콘서트"],
 };
+// 한국어 필터 이름을 영어 장르 배열로 변환하는 함수
+const getGenresByFilter = (filter: string) => {
+  if (filter.startsWith("전체")) {
+    return Object.keys(genreToFilter);
+  }
 
-const Filters = ({ genres }: FiltersPropTypes) => {
+  return Object.entries(genreToFilter)
+    .filter(([, filters]) => filters.includes(filter))
+    .map(([genre]) => genre);
+};
+
+const Filters = ({ genres, handleGenreClick }: FiltersPropTypes) => {
   const genreCounts = genres.reduce<{ [key: string]: number }>((genreCount, genre) => {
     const filterNames = genreToFilter[genre];
     if (filterNames) {
@@ -55,20 +66,11 @@ const Filters = ({ genres }: FiltersPropTypes) => {
   const [selectedOption, setSelectedOption] = useState<string>(options[0]);
   const [isOpen, setIsOpen] = useState<boolean>(false);
 
-  // useEffect(() => {
-  //   console.log(filters.length);
-  //   if (filters.length > 0) {
-  //     setActiveFilter(filters[0]);
-  //   }
-  // }, []);
-  // useEffect(() => {
-  //   if (filters.length > 0 && !activeFilter) {
-  //     setActiveFilter(filters[0]);
-  //   }
-  // }, [filters, activeFilter]);
-
   const handleFilterClick = (filter: string) => {
     setActiveFilter(filter);
+    const filterName = filter.slice(0, filter.indexOf("("));
+    const clickedGenres = getGenresByFilter(filterName);
+    handleGenreClick(clickedGenres);
   };
 
   const toggleDropdown = () => setIsOpen((prevIsOpen) => !prevIsOpen);

--- a/src/pages/SearchListPage/components/FiltersAndResult/FiltersAndResult.tsx
+++ b/src/pages/SearchListPage/components/FiltersAndResult/FiltersAndResult.tsx
@@ -34,7 +34,7 @@ const FiltersAndResult = () => {
     const result = await getSearchResult(word);
     setSearchResult(result);
 
-    const extractedGenres = result.map((item) => item.genre);
+    const extractedGenres = result.map((item: SearchResultPropTypes) => item.genre);
     setGenres(extractedGenres);
   };
   return (

--- a/src/pages/SearchListPage/components/FiltersAndResult/FiltersAndResult.tsx
+++ b/src/pages/SearchListPage/components/FiltersAndResult/FiltersAndResult.tsx
@@ -17,6 +17,7 @@ const FiltersAndResult = () => {
   const [searchResult, setSearchResult] = useState<SearchResultPropTypes[]>([]);
   const [genres, setGenres] = useState<string[]>([]);
   const [searchWord, setSearchWord] = useState<string | null>(null);
+  const [filteredGenres, setFilteredGenres] = useState<string[]>([]);
 
   useEffect(() => {
     const storedSearchWord = localStorage.getItem("searchWord");
@@ -30,6 +31,7 @@ const FiltersAndResult = () => {
       fetchSearchResults(searchWord);
     }
   }, [searchWord]);
+
   const fetchSearchResults = async (word: string) => {
     const result = await getSearchResult(word);
     setSearchResult(result);
@@ -37,10 +39,20 @@ const FiltersAndResult = () => {
     const extractedGenres = result.map((item: SearchResultPropTypes) => item.genre);
     setGenres(extractedGenres);
   };
+
+  const handleGenreClick = (clickedGenres: string[]) => {
+    setFilteredGenres(clickedGenres);
+  };
+
+  const filteredResults =
+    filteredGenres.length > 0
+      ? searchResult.filter((result) => filteredGenres.includes(result.genre))
+      : searchResult;
+
   return (
     <>
-      <Filters genres={genres} />
-      <FilteredResultList searchResult={searchResult} />
+      <Filters genres={genres} handleGenreClick={handleGenreClick} />
+      <FilteredResultList searchResult={filteredResults} />
     </>
   );
 };


### PR DESCRIPTION
### ✨ 해당 이슈 번호

resolved #90 

### 🌱 작업 내용

- [x] ~ 실시간 검색어에 일치하는 결과물이 있는지 확인하는 코드에서 더미 데이터에서 실제 데이터로 수정했습니다.
- [x] ~ 필터 클릭시 클릭된 장르에 해당하는 결과물 필터링 하는 기능 추가했습니다.


### ✅ PR Point
- 처음부터 Filter컴포넌트와 그 결과물 보여주는 컴포넌트의 부모 컴포넌트에 필터 상수 데이터를 명시해놓고 해도 됐었는데 지금 수정하기엔 살짝 늦은것 같아서 좀 번거롭지만 Filter 컴포넌트에서 클릭된 필터에 해당하는 장르를 부모 컴포넌트에 배열로 전달하여 거기서 결과를 보여주는 컴포넌트로 searchResult를 보내줄때 한번 더 필터링 해서 보내줍니다.


### 🌱 Trouble Shooting
- 개발 중 겪은 트러블 정리!


### 👀 스크린샷 (선택)

https://github.com/NOWSOPT-CDSP-WEB-7/YES24-WEB-CLIENT/assets/101498590/1009bfd5-47e4-4072-927e-2d4150b50af1



### 📚 Reference

